### PR TITLE
Update roadmap and tasks for Qt GUI packaging

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,3 +1,4 @@
 # Development Milestones
 
 - Initial structure setup
+- Windows packaging for Qt GUI

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,2 @@
 - [IN_PROGRESS] Execute project_structure.md and generate file structure
+- [TODO] (pc_agent) Plan Windows packaging workflow for Qt GUI

--- a/docs/design/project_roadmap.md
+++ b/docs/design/project_roadmap.md
@@ -1,0 +1,24 @@
+# project_roadmap.md – DDS-Controller
+
+This roadmap outlines upcoming development goals for the DDS-Controller project.
+It complements `MILESTONES.md` and `TODO.md` by providing a broader picture of
+planned features and major tasks.
+
+## 🗓️ Near Term
+
+- Finalize generated file structure.
+- Implement basic firmware modules (DDS driver, menu system, EEPROM access).
+- Begin development of cross-platform GUI using Qt.
+
+## 📦 Packaging Goals
+
+- Establish a Windows packaging workflow for the Qt GUI application.
+  - Create build scripts for Windows installers.
+  - Ensure serial communication libraries are bundled properly.
+
+## 🌐 Future Items
+
+- REST API for remote control via ESP8266.
+- Configuration preset management across firmware and PC layers.
+- Automated release pipeline with version tagging.
+

--- a/docs/progress/2025-06-18_0412_root_agent.md
+++ b/docs/progress/2025-06-18_0412_root_agent.md
@@ -1,0 +1,7 @@
+# Root Agent Coordination Log
+Date: 2025-06-18 04:12 CEST
+
+- Added `project_roadmap.md` with new packaging section for Qt GUI.
+- Updated `TODO.md` with planning task for Windows packaging workflow.
+- Extended `MILESTONES.md` to include Qt GUI Windows packaging milestone.
+


### PR DESCRIPTION
## Summary
- create `project_roadmap.md` documenting near-term goals
- add Windows packaging milestone for the Qt GUI
- update `TODO.md` with packaging task assigned to `pc_agent`
- log coordination steps for root agent

## Testing
- `make test` *(fails: no rule defined)*

------
https://chatgpt.com/codex/tasks/task_e_685220545c508322a70724081e0eb4df