### PR TITLE
Implement EEPROMManager save/load methods

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 - [DONE] Execute project_structure.md and generate file structure
 - [TODO] (esp_agent) Create ESP8266 UART bridge skeleton
-- [TODO] (storage_agent) Implement EEPROMManager class
+- [IN_PROGRESS] (storage_agent) Implement EEPROMManager class
 - [TODO] (pc_agent) Plan Windows packaging workflow for Qt GUI

--- a/docs/progress/2025-06-18_05-44-35_storage_agent.md
+++ b/docs/progress/2025-06-18_05-44-35_storage_agent.md
@@ -1,0 +1,7 @@
+# Storage Agent Progress Log
+Date: 2025-06-18 05:44:35 CEST
+
+- Extended `EEPROMManager` to handle frequency and waveform storage using I²C EEPROM.
+- Added generic byte read/write helpers for 24LC256 operations.
+- Updated header with simple memory map constants and new API.
+- Marked EEPROMManager task as IN_PROGRESS in `TODO.md`.

--- a/firmware/due/EEPROMManager.h
+++ b/firmware/due/EEPROMManager.h
@@ -4,11 +4,24 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+
+#define EEPROM_I2C_ADDRESS 0x50
+#define EEPROM_FREQ_ADDR 0x0000
+#define EEPROM_WAVEFORM_ADDR 0x0004
+
 class EEPROMManager {
 public:
   void begin();
-  uint32_t readFreq();
-  void writeFreq(uint32_t freq);
+
+  void saveFrequency(uint32_t freq);
+  uint32_t loadFrequency();
+
+  void saveWaveform(uint8_t wf);
+  uint8_t loadWaveform();
+
+private:
+  void writeBytes(uint16_t addr, const uint8_t* data, uint8_t len);
+  void readBytes(uint16_t addr, uint8_t* data, uint8_t len);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- extend EEPROMManager API for frequency and waveform storage
- add generic byte helpers for 24LC256 I²C EEPROM
- log storage agent progress
- mark EEPROM manager task as in progress

## Testing
- `arduino-cli` not available; no build performed

------
https://chatgpt.com/codex/tasks/task_e_685235a86cb48322a58d2dbb2e8787b3