### PR TITLE
Finalize EEPROM layout and add constants

### DIFF
--- a/docs/design/storage_map.md
+++ b/docs/design/storage_map.md
@@ -11,18 +11,20 @@ This document defines the structured storage layout for non-volatile memory used
 
 ## 🧩 Memory Regions
 
-| Offset (hex) | Size (bytes) | Description                  | Access      |
-| ------------ | ------------ | ---------------------------- | ----------- |
-| 0x0000       | 64           | Project identifier + version | R           |
-| 0x0040       | 128          | Preset 1                     | R/W         |
-| 0x00C0       | 128          | Preset 2                     | R/W         |
-| 0x0140       | 128          | Preset 3                     | R/W         |
-| 0x01C0       | 128          | Preset 4                     | R/W         |
-| 0x0240       | 128          | Preset 5                     | R/W         |
-| 0x02C0       | 64           | Default boot config          | R/W         |
-| 0x0300       | 128          | Menu UI settings             | R/W         |
-| 0x0380       | 256          | Reserved for expansion       | R/W         |
-| 0x0480       | 4096         | EEPROM ring buffer (logging) | Append-Only |
+The table below reflects the finalized layout for the 24LC256. Ranges are given in hexadecimal and use little endian encoding.
+
+| Range (hex)    | Size (bytes) | Type          | Description                          |
+| -------------- | ------------ | ------------- | ------------------------------------ |
+| 0x0000-0x0003  | 4            | `uint32_t`    | Output frequency (Hz)                |
+| 0x0004         | 1            | `uint8_t`     | Waveform ID                          |
+| 0x0005         | 1            | `uint8_t`     | Settings version ID                  |
+| 0x0006-0x00FF  | 250          | —             | Reserved for future config fields    |
+| 0x0100-0x017F  | 128          | `Preset`      | Preset slot 1                        |
+| 0x0180-0x01FF  | 128          | `Preset`      | Preset slot 2                        |
+| 0x0200-0x027F  | 128          | `Preset`      | Preset slot 3                        |
+| 0x0280-0x02FF  | 128          | `Preset`      | Preset slot 4                        |
+| 0x0300-0x037F  | 128          | `Preset`      | Preset slot 5                        |
+| 0x0380-0x7FFF  | 31,872       | —             | Reserved for additional presets/profiles |
 
 ## 📖 Encoding Format
 

--- a/docs/progress/2025-06-18_06-52-46_storage_agent_layout.md
+++ b/docs/progress/2025-06-18_06-52-46_storage_agent_layout.md
@@ -1,0 +1,7 @@
+# Storage Agent Progress Log
+Date: 2025-06-18 06:52:46 CEST
+
+- Finalized EEPROM memory map to match EEPROMManager implementation.
+- Added `EEPROMMap.h` with offset constants and `Settings` struct.
+- Updated `EEPROMManager` headers to use the map constants.
+- Documented hex ranges and data types in `storage_map.md`.

--- a/firmware/due/EEPROMManager.h
+++ b/firmware/due/EEPROMManager.h
@@ -3,11 +3,7 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-
-
-#define EEPROM_I2C_ADDRESS 0x50
-#define EEPROM_FREQ_ADDR 0x0000
-#define EEPROM_WAVEFORM_ADDR 0x0004
+#include "EEPROMMap.h"
 
 class EEPROMManager {
 public:

--- a/firmware/due/EEPROMMap.h
+++ b/firmware/due/EEPROMMap.h
@@ -1,0 +1,35 @@
+#ifndef EEPROM_MAP_H
+#define EEPROM_MAP_H
+
+#include <Arduino.h>
+
+#define EEPROM_I2C_ADDRESS 0x50
+
+// Basic settings
+#define EEPROM_ADDR_FREQ      0x0000
+#define EEPROM_ADDR_WAVEFORM  0x0004
+#define EEPROM_ADDR_VERSION   0x0005
+
+// Reserved space for additional configuration fields
+#define EEPROM_RESERVED_START 0x0006
+#define EEPROM_RESERVED_END   0x00FF
+
+// Preset storage
+#define EEPROM_PRESET_START   0x0100
+#define EEPROM_PRESET_SIZE    0x0080  // 128 bytes per preset
+#define EEPROM_PRESET_COUNT   5
+
+#define EEPROM_PRESET1_ADDR   (EEPROM_PRESET_START)
+#define EEPROM_PRESET2_ADDR   (EEPROM_PRESET_START + EEPROM_PRESET_SIZE)
+#define EEPROM_PRESET3_ADDR   (EEPROM_PRESET_START + 2 * EEPROM_PRESET_SIZE)
+#define EEPROM_PRESET4_ADDR   (EEPROM_PRESET_START + 3 * EEPROM_PRESET_SIZE)
+#define EEPROM_PRESET5_ADDR   (EEPROM_PRESET_START + 4 * EEPROM_PRESET_SIZE)
+
+// Struct used for bulk save/load if required
+struct Settings {
+    uint32_t frequency;
+    uint8_t  waveform;
+    uint8_t  version;
+} __attribute__((packed));
+
+#endif // EEPROM_MAP_H


### PR DESCRIPTION
## Summary
- add `EEPROMMap.h` with defined address layout
- reference new map from `EEPROMManager`
- describe final EEPROM layout in `storage_map.md`
- log storage agent progress

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68524581026c8322a2deccdfd1be9710