### PR TITLE
Implement preset management in menu system

### DIFF
--- a/docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md
+++ b/docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md
@@ -1,0 +1,7 @@
+# Firmware Agent Progress Log
+Date: 2025-06-18 07:42:12 CEST
+
+- Added preset management submenu and actions in `MenuSystem`.
+- Implemented EEPROMManager helpers for saving, loading and deleting presets.
+- Updated menu navigation logic with edit contexts for frequency and presets.
+- Extended display handling to show preset ID selection.

--- a/firmware/due/EEPROMManager.cpp
+++ b/firmware/due/EEPROMManager.cpp
@@ -5,23 +5,49 @@ void EEPROMManager::begin() {
 }
 
 void EEPROMManager::saveFrequency(uint32_t freq) {
-  writeBytes(EEPROM_FREQ_ADDR, (uint8_t *)&freq, sizeof(freq));
+  writeBytes(EEPROM_ADDR_FREQ, (uint8_t *)&freq, sizeof(freq));
 }
 
 uint32_t EEPROMManager::loadFrequency() {
   uint32_t val = 0;
-  readBytes(EEPROM_FREQ_ADDR, (uint8_t *)&val, sizeof(val));
+  readBytes(EEPROM_ADDR_FREQ, (uint8_t *)&val, sizeof(val));
   return val;
 }
 
 void EEPROMManager::saveWaveform(uint8_t wf) {
-  writeBytes(EEPROM_WAVEFORM_ADDR, &wf, sizeof(wf));
+  writeBytes(EEPROM_ADDR_WAVEFORM, &wf, sizeof(wf));
 }
 
 uint8_t EEPROMManager::loadWaveform() {
   uint8_t wf = 0;
-  readBytes(EEPROM_WAVEFORM_ADDR, &wf, sizeof(wf));
+  readBytes(EEPROM_ADDR_WAVEFORM, &wf, sizeof(wf));
   return wf;
+}
+
+void EEPROMManager::savePreset(uint8_t id, uint32_t freq, uint8_t waveform) {
+  if (id == 0 || id > EEPROM_PRESET_COUNT)
+    return;
+  Settings s{freq, waveform, 1};
+  uint16_t addr = EEPROM_PRESET_START + (id - 1) * EEPROM_PRESET_SIZE;
+  writeBytes(addr, reinterpret_cast<const uint8_t *>(&s), sizeof(s));
+}
+
+void EEPROMManager::loadPreset(uint8_t id, uint32_t &freq, uint8_t &waveform) {
+  if (id == 0 || id > EEPROM_PRESET_COUNT)
+    return;
+  Settings s{};
+  uint16_t addr = EEPROM_PRESET_START + (id - 1) * EEPROM_PRESET_SIZE;
+  readBytes(addr, reinterpret_cast<uint8_t *>(&s), sizeof(s));
+  freq = s.frequency;
+  waveform = s.waveform;
+}
+
+void EEPROMManager::deletePreset(uint8_t id) {
+  if (id == 0 || id > EEPROM_PRESET_COUNT)
+    return;
+  Settings s{};
+  uint16_t addr = EEPROM_PRESET_START + (id - 1) * EEPROM_PRESET_SIZE;
+  writeBytes(addr, reinterpret_cast<const uint8_t *>(&s), sizeof(s));
 }
 
 void EEPROMManager::writeBytes(uint16_t addr, const uint8_t *data, uint8_t len) {

--- a/firmware/due/EEPROMManager.h
+++ b/firmware/due/EEPROMManager.h
@@ -15,6 +15,10 @@ public:
   void saveWaveform(uint8_t wf);
   uint8_t loadWaveform();
 
+  void savePreset(uint8_t id, uint32_t freq, uint8_t waveform);
+  void loadPreset(uint8_t id, uint32_t &freq, uint8_t &waveform);
+  void deletePreset(uint8_t id);
+
 private:
   void writeBytes(uint16_t addr, const uint8_t* data, uint8_t len);
   void readBytes(uint16_t addr, uint8_t* data, uint8_t len);

--- a/firmware/due/MenuSystem.h
+++ b/firmware/due/MenuSystem.h
@@ -30,6 +30,10 @@ private:
         SYSTEM_MENU,
         SHOW_VERSION,
         RESET_DEFAULTS,
+        PRESET_MENU,
+        PRESET_SAVE,
+        PRESET_LOAD,
+        PRESET_DELETE,
         EXIT_MENU
     };
 
@@ -48,7 +52,13 @@ private:
     DDSDriver& dds;
 
     MenuID current;
-    uint16_t freq;
+    uint32_t freq;
+    uint8_t waveform;
+
+    enum class EditContext { NONE, FREQ, PRESET_SAVE, PRESET_LOAD, PRESET_DELETE };
+    EditContext editContext = EditContext::NONE;
+    uint8_t editPresetId = 1;
+    uint32_t editValue = 0;
 
     void display();
     void navigate();


### PR DESCRIPTION
## Summary
- extend `MenuSystem` with Presetek submenu and preset operations
- track waveform and preset selection state
- add preset helpers to `EEPROMManager`
- document progress

## Testing
- `g++ -std=c++17 -c firmware/due/MenuSystem.cpp firmware/due/EEPROMManager.cpp` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68525095edbc8322902e69adcff2582c