### PR TITLE
Add g++ mock build support

### DIFF
--- a/AD9850Driver.h
+++ b/AD9850Driver.h
@@ -1,7 +1,11 @@
 // AD9850Driver.h
 #ifndef AD9850_DRIVER_H
 #define AD9850_DRIVER_H
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "firmware/due/mocks/Arduino.h"
+#endif
 
 #define DDS_PIN_DATA   10
 #define DDS_PIN_W_CLK  11

--- a/ButtonManager.h
+++ b/ButtonManager.h
@@ -1,7 +1,11 @@
 // ButtonManager.h
 #ifndef BUTTON_MANAGER_H
 #define BUTTON_MANAGER_H
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "firmware/due/mocks/Arduino.h"
+#endif
 
 #define BUTTON_PIN A0
 

--- a/ConfigStore.h
+++ b/ConfigStore.h
@@ -1,8 +1,13 @@
 // ConfigStore.h
 #ifndef CONFIG_STORE_H
 #define CONFIG_STORE_H
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <Wire.h>
+#else
+#include "firmware/due/mocks/Arduino.h"
+#include "firmware/due/mocks/Wire.h"
+#endif
 
 #define EEPROM_ADDR_FREQ       0   // int32_t
 #define EEPROM_ADDR_WAVEFORM   4   // uint8_t

--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -1,8 +1,13 @@
 // DisplayManager.h
 #ifndef DISPLAY_MANAGER_H
 #define DISPLAY_MANAGER_H
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <LiquidCrystal.h>
+#else
+#include "firmware/due/mocks/Arduino.h"
+#include "firmware/due/mocks/LiquidCrystal.h"
+#endif
 
 #define LCD_PIN_RS 8
 #define LCD_PIN_EN 9

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -I. -Ifirmware/due
+
+SRCS = $(wildcard *.cpp) $(wildcard firmware/due/*.cpp) firmware/due/mocks/Wire.cpp
+OBJS = $(SRCS:.cpp=.o)
+
+.PHONY: test_build clean
+
+test_build: $(OBJS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS)

--- a/docs/progress/2025-06-18_07-50-43_firmware_agent_mock_build.md
+++ b/docs/progress/2025-06-18_07-50-43_firmware_agent_mock_build.md
@@ -1,0 +1,7 @@
+# Firmware Agent Progress Log
+Date: 2025-06-18 07:50:43 CEST
+
+- Added mock Arduino headers for desktop compilation under `firmware/due/mocks`.
+- Created generic Makefile with `test_build` target for g++.
+- Updated firmware headers to include mocks when `ARDUINO` is undefined.
+- Verified successful object compilation via `make test_build`.

--- a/firmware/due/DDSDriver.h
+++ b/firmware/due/DDSDriver.h
@@ -1,0 +1,13 @@
+#ifndef DDS_DRIVER_H
+#define DDS_DRIVER_H
+
+#include <stdint.h>
+
+class DDSDriver {
+public:
+    void begin();
+    void setFrequency(uint32_t freq);
+    void setWaveform(uint8_t type);
+};
+
+#endif // DDS_DRIVER_H

--- a/firmware/due/EEPROMManager.h
+++ b/firmware/due/EEPROMManager.h
@@ -1,8 +1,13 @@
 #ifndef EEPROM_MANAGER_H
 #define EEPROM_MANAGER_H
 
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <Wire.h>
+#else
+#include "mocks/Arduino.h"
+#include "mocks/Wire.h"
+#endif
 #include "EEPROMMap.h"
 
 class EEPROMManager {

--- a/firmware/due/EEPROMMap.h
+++ b/firmware/due/EEPROMMap.h
@@ -1,7 +1,11 @@
 #ifndef EEPROM_MAP_H
 #define EEPROM_MAP_H
 
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "mocks/Arduino.h"
+#endif
 
 #define EEPROM_I2C_ADDRESS 0x50
 

--- a/firmware/due/MenuSystem.h
+++ b/firmware/due/MenuSystem.h
@@ -2,8 +2,13 @@
 #ifndef MENUSYSTEM_H
 #define MENUSYSTEM_H
 
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <LiquidCrystal.h>
+#else
+#include "mocks/Arduino.h"
+#include "mocks/LiquidCrystal.h"
+#endif
 #include "ButtonManager.h"
 #include "EEPROMManager.h"
 #include "DDSDriver.h"
@@ -13,7 +18,6 @@ public:
     MenuSystem(LiquidCrystal& lcd, ButtonManager& buttons, EEPROMManager& eeprom, DDSDriver& dds);
     void update();
 
-private:
     enum MenuID {
         MAIN_MENU,
         FREQ_SETTINGS,
@@ -46,6 +50,7 @@ private:
         bool editable;
     };
 
+private:
     LiquidCrystal& lcd;
     ButtonManager& buttons;
     EEPROMManager& eeprom;

--- a/firmware/due/mocks/Arduino.h
+++ b/firmware/due/mocks/Arduino.h
@@ -1,0 +1,24 @@
+#ifndef ARDUINO_MOCK_H
+#define ARDUINO_MOCK_H
+
+#include <cstdint>
+#include <string>
+
+#define HIGH 0x1
+#define LOW  0x0
+#define INPUT 0x0
+#define OUTPUT 0x1
+#define INPUT_PULLUP 0x2
+
+#define A0 0
+
+inline void pinMode(int, int) {}
+inline void digitalWrite(int, int) {}
+inline int analogRead(int) { return 0; }
+inline unsigned long millis() { return 0; }
+inline void delay(unsigned long) {}
+inline void delayMicroseconds(unsigned int) {}
+
+using String = std::string;
+
+#endif // ARDUINO_MOCK_H

--- a/firmware/due/mocks/LiquidCrystal.h
+++ b/firmware/due/mocks/LiquidCrystal.h
@@ -1,0 +1,15 @@
+#ifndef LIQUIDCRYSTAL_MOCK_H
+#define LIQUIDCRYSTAL_MOCK_H
+
+class LiquidCrystal {
+public:
+    LiquidCrystal(int,int,int,int,int,int) {}
+    void begin(int, int) {}
+    void clear() {}
+    void setCursor(int, int) {}
+    void print(const char*) {}
+    template <typename T>
+    void print(T) {}
+};
+
+#endif // LIQUIDCRYSTAL_MOCK_H

--- a/firmware/due/mocks/README.md
+++ b/firmware/due/mocks/README.md
@@ -1,0 +1,1 @@
+This directory provides simple mock headers so the firmware modules can be compiled with a standard g++ toolchain. When building for Arduino, the normal Arduino headers are used. When ARDUINO is not defined, the build should include these mocks instead.

--- a/firmware/due/mocks/Wire.cpp
+++ b/firmware/due/mocks/Wire.cpp
@@ -1,0 +1,2 @@
+#include "Wire.h"
+TwoWire Wire;

--- a/firmware/due/mocks/Wire.h
+++ b/firmware/due/mocks/Wire.h
@@ -1,0 +1,19 @@
+#ifndef WIRE_MOCK_H
+#define WIRE_MOCK_H
+
+#include <cstdint>
+
+class TwoWire {
+public:
+    void begin() {}
+    void beginTransmission(int) {}
+    void write(uint8_t) {}
+    void endTransmission() {}
+    void requestFrom(int, int) {}
+    int available() { return 0; }
+    int read() { return 0; }
+};
+
+extern TwoWire Wire;
+
+#endif // WIRE_MOCK_H


### PR DESCRIPTION
## Summary
- add stubbed Arduino headers in `firmware/due/mocks`
- create `DDSDriver.h` placeholder
- update firmware headers to use mocks when ARDUINO is not defined
- add Makefile for desktop compilation
- log mock build progress

## Testing
- `make clean`
- `make test_build`

------
https://chatgpt.com/codex/tasks/task_e_68525290aa4c83228af3b0f8d021a61c