### PR TITLE
Add file audit log

### DIFF
--- a/logs/2025-06-18_07-57-08_file_audit.md
+++ b/logs/2025-06-18_07-57-08_file_audit.md
@@ -1,0 +1,28 @@
+# File Audit Report – 2025-06-18
+
+The following files were flagged during the project directory audit on 2025-06-18_07-57-08 (CEST):
+
+| File | Reason |
+|------|--------|
+| AD9850Driver.cpp | Legacy firmware source at root, not in documented structure |
+| AD9850Driver.h | Legacy firmware header at root |
+| ButtonManager.cpp | Legacy firmware source at root |
+| ButtonManager.h | Legacy firmware header at root |
+| ConfigStore.cpp | Legacy firmware source at root |
+| ConfigStore.h | Legacy firmware header at root |
+| DisplayManager.cpp | Legacy firmware source at root |
+| DisplayManager.h | Legacy firmware header at root |
+| DDS_Controller.ino | Legacy sketch at root |
+| firmware/due/mocks/README.md | Documentation inside firmware section |
+| firmware/esp/web_ui/index.html | Non-source file in firmware tree |
+| docs/prompts/esp_agent/.gitkeep | Non-document file under docs |
+| docs/prompts/firmware_agent/.gitkeep | Non-document file under docs |
+| docs/prompts/pc_agent/.gitkeep | Non-document file under docs |
+| pc/gui/Views/.gitkeep | Placeholder file in GUI directory |
+| docs/design/project_roadmap.md & docs/project_roadmap.md | Duplicate roadmap documents |
+| protocol/rest/ | Folder not in specified protocol layout |
+| pc/test_tools/README.md | Test tools documentation in pc directory |
+
+Total flagged items: 18
+
+Deletion has not been performed yet. Please confirm if these files should be removed.


### PR DESCRIPTION
## Summary
- generate file audit report listing out-of-place or unused files

## Testing
- `make test_build`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_685254c49c50832284bdb0112ef37150