### PR TITLE
Update docs_agent entry and add documentation audit log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ This project follows a **file-driven agent-based development model**, coordinate
 
 ## 🧩 Active Agents
 
+### 🧭 `root_agent`
+- Enforces documentation presence and alignment with project structure. Triggers updates for every undocumented source file and version gap.
+
 ### ⚙️ `firmware_agent`
 - Implements the Arduino Due firmware:
   - `DDSDriver`, `MenuSystem`, `EEPROMManager`, `CommandParser`
@@ -67,8 +70,10 @@ This project follows a **file-driven agent-based development model**, coordinate
 - Handles default boot config, fallback values, and system presets
 
 ### 🧱 `docs_agent`
-- Generates Markdown documentation for structure, usage, and internal APIs
-- Builds `docs/dev_protocols/`, `docs/design/`, `docs/prompts/`
+- Responsible for real-time documentation of all modules and logic.
+- Audits progress and updates logs.
+- Documents all newly created code components automatically.
+- Builds `docs/dev_protocols/`, `docs/design/`, `docs/prompts/`.
 
 ### ⌨️ `structure_agent`
 - Executes the project file layout defined in `docs/design/proj.struct.md`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,7 +2,7 @@
 
 This project uses several specialized agents that collaborate through files and prompts. Below is a brief summary of their roles.
 
-- **root_agent** – coordinates all other agents and approves milestone progression.
+- **root_agent** – enforces documentation presence and alignment with project structure. Triggers updates for every undocumented source file and version gap.
 - **firmware_agent** – maintains Arduino Due firmware under `firmware/due/`.
 - **esp_agent** – handles ESP8266 firmware in `firmware/esp/`.
 - **protocol_agent** – defines communication formats within `protocol/`.
@@ -10,7 +10,7 @@ This project uses several specialized agents that collaborate through files and 
 - **storage_agent** – manages EEPROM layout and persistence logic.
 - **validation_agent** – enforces value ranges and command correctness.
 - **config_agent** – supplies default system presets.
-- **docs_agent** – keeps documentation up to date in `docs/`.
+- **docs_agent** – responsible for real-time documentation of all modules and logic. Audits progress and updates logs. Documents all newly created code components automatically.
 - **structure_agent** – applies `docs/design/project_structure.md`.
 - **timeline_agent** – logs progress to `docs/progress/` and maintains `docs/versions/`.
 

--- a/docs/impl/Arduino.md
+++ b/docs/impl/Arduino.md
@@ -1,0 +1,3 @@
+# Arduino Implementation
+
+Placeholder documentation for `firmware/due/mocks/Arduino.h`.

--- a/docs/impl/ButtonManager.md
+++ b/docs/impl/ButtonManager.md
@@ -1,0 +1,3 @@
+# ButtonManager Implementation
+
+Placeholder documentation for `firmware/due/ButtonManager.cpp`.

--- a/docs/impl/CommandParser.md
+++ b/docs/impl/CommandParser.md
@@ -1,0 +1,3 @@
+# CommandParser Implementation
+
+Placeholder documentation for `firmware/due/CommandParser.h`.

--- a/docs/impl/DDSDriver.md
+++ b/docs/impl/DDSDriver.md
@@ -1,0 +1,3 @@
+# DDSDriver Implementation
+
+Placeholder documentation for `firmware/due/DDSDriver.cpp`.

--- a/docs/impl/EEPROMManager.md
+++ b/docs/impl/EEPROMManager.md
@@ -1,0 +1,3 @@
+# EEPROMManager Implementation
+
+Placeholder documentation for `firmware/due/EEPROMManager.h`.

--- a/docs/impl/EEPROMMap.md
+++ b/docs/impl/EEPROMMap.md
@@ -1,0 +1,3 @@
+# EEPROMMap Implementation
+
+Placeholder documentation for `firmware/due/EEPROMMap.h`.

--- a/docs/impl/LiquidCrystal.md
+++ b/docs/impl/LiquidCrystal.md
@@ -1,0 +1,3 @@
+# LiquidCrystal Implementation
+
+Placeholder documentation for `firmware/due/mocks/LiquidCrystal.h`.

--- a/docs/impl/MainWindow.md
+++ b/docs/impl/MainWindow.md
@@ -1,0 +1,3 @@
+# MainWindow Implementation
+
+Placeholder documentation for `pc/gui/MainWindow.go`.

--- a/docs/impl/MenuSystem.md
+++ b/docs/impl/MenuSystem.md
@@ -1,0 +1,3 @@
+# MenuSystem Implementation
+
+Placeholder documentation for `firmware/due/MenuSystem.h`.

--- a/docs/impl/SerialBridge.md
+++ b/docs/impl/SerialBridge.md
@@ -1,0 +1,3 @@
+# SerialBridge Implementation
+
+Placeholder documentation for `pc/gui/SerialBridge.go`.

--- a/docs/impl/Wire.md
+++ b/docs/impl/Wire.md
@@ -1,0 +1,3 @@
+# Wire Implementation
+
+Placeholder documentation for `firmware/due/mocks/Wire.cpp`.

--- a/docs/impl/commands.md
+++ b/docs/impl/commands.md
@@ -1,0 +1,3 @@
+# commands Implementation
+
+Placeholder documentation for `firmware/shared/commands.h`.

--- a/docs/impl/ddsctl.md
+++ b/docs/impl/ddsctl.md
@@ -1,0 +1,3 @@
+# ddsctl Implementation
+
+Placeholder documentation for `pc/cli/ddsctl.py`.

--- a/docs/impl/main.md
+++ b/docs/impl/main.md
@@ -1,0 +1,3 @@
+# main Implementation
+
+Placeholder documentation for `firmware/due/main.ino`.

--- a/docs/impl/main_esp.md
+++ b/docs/impl/main_esp.md
@@ -1,0 +1,3 @@
+# main_esp Implementation
+
+Placeholder documentation for `firmware/esp/main.ino`.

--- a/docs/impl/presets.md
+++ b/docs/impl/presets.md
@@ -1,0 +1,3 @@
+# presets Implementation
+
+Placeholder documentation for `pc/config/presets.json`.

--- a/docs/impl/validator.md
+++ b/docs/impl/validator.md
@@ -1,0 +1,3 @@
+# validator Implementation
+
+Placeholder documentation for `protocol/ascii/validator.py`.

--- a/docs/progress/2025-06-18_08-51-02_docs_agent_audit.md
+++ b/docs/progress/2025-06-18_08-51-02_docs_agent_audit.md
@@ -1,0 +1,5 @@
+# Documentation Audit
+
+- Updated AGENTS.md entries for root_agent and docs_agent.
+- Created docs/impl/ stubs for existing source files.
+- Verified presence of prompts and design docs.


### PR DESCRIPTION
## Summary
- refine docs_agent role in AGENTS files and list root_agent as active
- generate stub docs for every code module under docs/impl
- add a documentation audit progress log

## Testing
- `make test_build`


------
https://chatgpt.com/codex/tasks/task_e_685261298e248322b434a0ac28dd27a1