### PR TITLE
Fill implementation docs

### DIFF
--- a/docs/impl/Arduino.md
+++ b/docs/impl/Arduino.md
@@ -1,3 +1,19 @@
-# Arduino Implementation
+# Arduino Mock Implementation
 
-Placeholder documentation for `firmware/due/mocks/Arduino.h`.
+`firmware/due/mocks/Arduino.h` provides a minimal subset of the Arduino API so that the
+firmware sources can be compiled on a desktop PC. It defines common macros like
+`HIGH`, `LOW`, `INPUT` and `OUTPUT` and implements the basic functions used by the
+project:
+
+- `pinMode()`
+- `digitalWrite()`
+- `analogRead()`
+- `millis()`
+- `delay()` / `delayMicroseconds()`
+
+All functions are empty inline stubs that return default values. They allow unit
+or build tests to run without access to the real microcontroller environment.
+No timing or I/O behaviour is emulated, therefore the mock should only be used
+for compilation tests and not for functional verification.
+
+Dependencies: standard C++ headers only.

--- a/docs/impl/ButtonManager.md
+++ b/docs/impl/ButtonManager.md
@@ -1,3 +1,17 @@
 # ButtonManager Implementation
 
-Placeholder documentation for `firmware/due/ButtonManager.cpp`.
+`ButtonManager` abstracts the analog keypad of the LCD shield. It reads the
+shared analog pin and resolves it to one of the `ButtonCode` values defined in
+`ButtonManager.h`.
+
+## Key Methods
+- `begin()` – sets up the button pin for input and resets internal state.
+- `update()` – should be called periodically; reads the analog value and applies
+  simple debounce filtering.
+- `isPressed(code)` – returns `true` while the given button is held down.
+- `wasReleased(code)` – detects button release events used for menu navigation.
+
+The analog thresholds and debounce delay (50 ms) are hard coded. The module is
+used by `MenuSystem` to drive the UI state machine as shown in
+`docs/design/menu_navigation.md` and referenced in progress logs such as
+`2025-06-18_0436_firmware_agent_menu.md`.

--- a/docs/impl/CommandParser.md
+++ b/docs/impl/CommandParser.md
@@ -1,3 +1,18 @@
 # CommandParser Implementation
 
-Placeholder documentation for `firmware/due/CommandParser.h`.
+`CommandParser` provides a tiny ASCII command handler for the Arduino firmware.
+It is used by both the USB and ESP8266 serial interfaces.
+
+## API
+- `begin(DDSDriver&, EEPROMManager&)` – stores pointers to the driver and EEPROM
+  helpers used by the parser.
+- `handleCommand(const String& cmd)` – interprets a single line without the
+  newline character.
+
+The implementation currently supports `SETFREQ` and `GETFREQ` as defined in
+`docs/dev_protocols/command_spec.md`. Additional commands can be added following
+that specification. All parsing is case-sensitive and relies on `std::strtoul`
+for numeric conversion.
+
+Progress logs `2025-06-18_16-55_root_agent_remediation.md` mention the initial
+stub creation.

--- a/docs/impl/DDSDriver.md
+++ b/docs/impl/DDSDriver.md
@@ -1,3 +1,14 @@
 # DDSDriver Implementation
 
-Placeholder documentation for `firmware/due/DDSDriver.cpp`.
+`DDSDriver` is a lightweight wrapper intended for controlling the AD9850 DDS
+module. The current implementation is only a stub that exposes three methods:
+
+- `begin()` – placeholder for hardware initialisation.
+- `setFrequency(uint32_t freq)` – expected to program the DDS with the given
+  frequency in Hertz.
+- `setWaveform(uint8_t type)` – select the output waveform.
+
+The driver is used by both `MenuSystem` and `CommandParser`. Implementation
+work is tracked in the root agent remediation log
+`2025-06-18_16-55_root_agent_remediation.md`. Future revisions should implement
+the 40‑bit serial control sequence required by the AD9850.

--- a/docs/impl/EEPROMManager.md
+++ b/docs/impl/EEPROMManager.md
@@ -1,3 +1,21 @@
 # EEPROMManager Implementation
 
-Placeholder documentation for `firmware/due/EEPROMManager.h`.
+`EEPROMManager` handles persistent configuration stored in the external 24LC256
+EEPROM. The memory layout is defined in `firmware/due/EEPROMMap.h` and documented
+in `docs/design/storage_map.md`.
+
+## Public API
+- `begin()` – initialises the I²C interface via `Wire`.
+- `saveFrequency(uint32_t)` / `loadFrequency()` – store or retrieve the last
+  used frequency.
+- `saveWaveform(uint8_t)` / `loadWaveform()` – same for waveform selection.
+- `savePreset(id, freq, wave)` / `loadPreset(id, freq, wave)` – manage five
+  preset slots (`EEPROM_PRESET_COUNT`).
+- `deletePreset(id)` – clear a preset slot.
+
+## Internal Helpers
+`writeBytes()` and `readBytes()` perform byte level access to the EEPROM and
+include a short delay after each write cycle. All addresses are 16‑bit and
+little endian as documented in the progress logs
+`2025-06-18_05-44-35_storage_agent.md` and
+`2025-06-18_06-52-46_storage_agent_layout.md`.

--- a/docs/impl/EEPROMMap.md
+++ b/docs/impl/EEPROMMap.md
@@ -1,3 +1,18 @@
 # EEPROMMap Implementation
 
-Placeholder documentation for `firmware/due/EEPROMMap.h`.
+`EEPROMMap.h` defines the address layout used by `EEPROMManager`. The constants
+mirror the table found in `docs/design/storage_map.md`.
+
+```cpp
+#define EEPROM_ADDR_FREQ      0x0000
+#define EEPROM_ADDR_WAVEFORM  0x0004
+#define EEPROM_ADDR_VERSION   0x0005
+#define EEPROM_PRESET_START   0x0100
+#define EEPROM_PRESET_SIZE    0x0080
+#define EEPROM_PRESET_COUNT   5
+```
+
+The optional `Settings` struct packs frequency, waveform and a version byte into
+a single record for preset storage. Any change in this map must stay in sync with
+the design document and the progress logs that tracked its creation
+(`2025-06-18_06-52-46_storage_agent_layout.md`).

--- a/docs/impl/LiquidCrystal.md
+++ b/docs/impl/LiquidCrystal.md
@@ -1,3 +1,9 @@
-# LiquidCrystal Implementation
+# LiquidCrystal Mock Implementation
 
-Placeholder documentation for `firmware/due/mocks/LiquidCrystal.h`.
+`firmware/due/mocks/LiquidCrystal.h` provides a bare bones stand‑in for the
+Arduino `LiquidCrystal` class. It implements the constructor and methods used by
+`MenuSystem` such as `begin()`, `clear()`, `setCursor()`, and `print()`.
+
+Each function is empty and performs no I/O. The mock exists so that the firmware
+can be compiled and linked on a PC during `make test_build` without an actual
+LCD attached. No cursor state or display content is tracked.

--- a/docs/impl/MainWindow.md
+++ b/docs/impl/MainWindow.md
@@ -1,3 +1,10 @@
 # MainWindow Implementation
 
-Placeholder documentation for `pc/gui/MainWindow.go`.
+`pc/gui/MainWindow.go` contains the entry point for the planned Go/Fyne based
+GUI. The current version only opens a window with a static label, but the design
+in `docs/design/pc_ui_mockups.md` shows the intended layout with frequency
+controls, waveform selection and serial port management.
+
+Future work will connect to `SerialBridge.go` for USB communication and mirror
+the same commands defined for the CLI tool. The window is created via
+`fyne.io/fyne/v2/app` and uses standard Fyne widgets.

--- a/docs/impl/MenuSystem.md
+++ b/docs/impl/MenuSystem.md
@@ -1,3 +1,23 @@
 # MenuSystem Implementation
 
-Placeholder documentation for `firmware/due/MenuSystem.h`.
+The `MenuSystem` class implements the LCD based user interface described in
+`docs/design/menu_navigation.md`. It manages a hierarchy of `MenuItem` structs
+and tracks the current state using the `MenuID` enum.
+
+## Construction
+`MenuSystem(LiquidCrystal&, ButtonManager&, EEPROMManager&, DDSDriver&)` sets up
+references to the dependencies. On startup the last saved frequency and waveform
+are loaded from EEPROM and applied via `DDSDriver`.
+
+## Runtime Flow
+`update()` should be called in the main loop. It polls the buttons,
+processes navigation or editing states and finally updates the display.
+Internal helpers:
+- `navigate()` – handles button driven state transitions and edit contexts.
+- `applyAction(MenuID)` – executes non-navigational actions like saving values.
+- `display()` – renders the parent label and current menu item on the LCD.
+
+Frequency editing is clamped between 1 Hz and 40 MHz with a 1 kHz step as noted
+in progress log `2025-06-18_0459_firmware_agent_menusystem_review.md`.
+Preset management actions rely on `EEPROMManager` and were added in
+`2025-06-18_07-42-12_firmware_agent_presets.md`.

--- a/docs/impl/SerialBridge.md
+++ b/docs/impl/SerialBridge.md
@@ -1,3 +1,9 @@
 # SerialBridge Implementation
 
-Placeholder documentation for `pc/gui/SerialBridge.go`.
+`SerialBridge.go` provides minimal helpers for opening a serial port from the Go
+GUI. It wraps the `tarm/serial` package and currently exposes only the
+`openPort(name, baud)` function which returns a `serial.Port` object.
+
+The bridge will be used by `MainWindow.go` to forward commands to the Arduino Due
+using the ASCII protocol defined in `docs/dev_protocols/command_spec.md`. The
+implementation is still a placeholder without error handling or message parsing.

--- a/docs/impl/Wire.md
+++ b/docs/impl/Wire.md
@@ -1,3 +1,10 @@
-# Wire Implementation
+# Wire Mock Implementation
 
-Placeholder documentation for `firmware/due/mocks/Wire.cpp`.
+The files `firmware/due/mocks/Wire.h` and `Wire.cpp` provide a tiny replacement
+for the Arduino `Wire` (I²C) library. The `TwoWire` class implements the methods
+used by `EEPROMManager` such as `begin()`, `beginTransmission()`, `write()`,
+`endTransmission()`, `requestFrom()`, `available()` and `read()`.
+
+All methods are empty and return fixed values; they allow the firmware to be
+compiled on a PC without linking against the real Arduino core. A single global
+instance `Wire` is defined in `Wire.cpp`.

--- a/docs/impl/commands.md
+++ b/docs/impl/commands.md
@@ -1,3 +1,7 @@
-# commands Implementation
+# commands.h
 
-Placeholder documentation for `firmware/shared/commands.h`.
+`firmware/shared/commands.h` is meant to hold shared command string constants for
+both the Arduino firmware and the ESP/PC tools. At the moment it contains only a
+placeholder comment. Command definitions should match the ASCII protocol
+specified in `docs/dev_protocols/command_spec.md` once the implementation is
+expanded.

--- a/docs/impl/ddsctl.md
+++ b/docs/impl/ddsctl.md
@@ -1,3 +1,10 @@
 # ddsctl Implementation
 
-Placeholder documentation for `pc/cli/ddsctl.py`.
+`ddsctl.py` is a very small CLI wrapper used for quick testing of the ASCII
+command protocol from a PC. It currently supports only `setfreq` and `getfreq`
+commands and prints simple text responses.
+
+The tool is described in `docs/design/pc_ui_mockups.md` and shares the same
+command set as the GUI. In a full implementation it would open the serial port,
+validate the command via `protocol/ascii/validator.py` and display the firmware
+response.

--- a/docs/impl/main.md
+++ b/docs/impl/main.md
@@ -1,3 +1,10 @@
-# main Implementation
+# main.ino
 
-Placeholder documentation for `firmware/due/main.ino`.
+The `firmware/due/main.ino` sketch will initialise all firmware modules and run
+the main loop. At the moment it is only a placeholder. According to
+`docs/design/architecture_overview.md` the final version should:
+
+1. instantiate `DDSDriver`, `EEPROMManager`, `ButtonManager`, `MenuSystem` and
+   `CommandParser`;
+2. set up serial ports for USB and ESP8266 communication; and
+3. call `MenuSystem.update()` repeatedly inside `loop()`.

--- a/docs/impl/main_esp.md
+++ b/docs/impl/main_esp.md
@@ -1,3 +1,7 @@
-# main_esp Implementation
+# ESP8266 Firmware
 
-Placeholder documentation for `firmware/esp/main.ino`.
+`firmware/esp/main.ino` implements the optional WiFi bridge described in
+`docs/design/architecture_overview.md`. The current code only echoes received
+serial data back to the sender. Future versions should initialise the ESP8266
+module, connect to a WLAN and expose a small REST API as outlined in
+`docs/design/protocol_layers.md`.

--- a/docs/impl/presets.md
+++ b/docs/impl/presets.md
@@ -1,3 +1,6 @@
-# presets Implementation
+# presets.json
 
-Placeholder documentation for `pc/config/presets.json`.
+The file `pc/config/presets.json` is intended to store user defined frequency and
+waveform presets for the PC tools. It is currently empty. The structure should
+mirror the `Preset` records used in `EEPROMManager` so that settings can be
+loaded and saved consistently across the PC GUI and the Arduino.

--- a/docs/impl/validator.md
+++ b/docs/impl/validator.md
@@ -1,3 +1,9 @@
-# validator Implementation
+# validator.py
 
-Placeholder documentation for `protocol/ascii/validator.py`.
+`protocol/ascii/validator.py` offers a simple regex based validator for the ASCII
+command protocol. The `VALID_COMMANDS` dictionary defines one pattern per
+command as described in `docs/dev_protocols/command_spec.md`.
+
+Use `validate_command(cmd: str) -> bool` to check if an input line matches any of
+the allowed patterns. The script can also run interactively from the command line
+for quick manual testing.

--- a/docs/progress/2025-06-18_09-00-17_docs_agent_impl_update.md
+++ b/docs/progress/2025-06-18_09-00-17_docs_agent_impl_update.md
@@ -1,0 +1,14 @@
+# Docs Agent Progress Log
+Date: 2025-06-18 09:00:17 CEST
+
+- Expanded documentation in `docs/impl/` for multiple modules:
+  - Added summaries for mock libraries (`Arduino`, `LiquidCrystal`, `Wire`).
+  - Documented firmware components `ButtonManager`, `CommandParser`, `DDSDriver`,
+    `EEPROMManager`, `EEPROMMap` and `MenuSystem` using code and progress logs.
+  - Created notes for PC tools (`MainWindow`, `SerialBridge`, `ddsctl`) and
+    configuration files (`presets.json`).
+  - Added brief descriptions for `main.ino` and `main_esp.ino` based on
+    architecture docs.
+  - Documented protocol helper `validator.py` and placeholder `commands.h`.
+- Source references include `storage_agent_layout` and `firmware_agent` logs as
+  well as design documents in `docs/design/`.


### PR DESCRIPTION
## Summary
- document firmware modules like EEPROMManager and MenuSystem
- describe mock helpers (Arduino, Wire, LiquidCrystal)
- note placeholders for CLI, GUI and ESP firmware
- log documentation update

## Testing
- `make test_build`

------
https://chatgpt.com/codex/tasks/task_e_685262ea21048322ae13faf7f2dcfb2c