### PR TITLE
root_agent stage 21 dispatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 - [IN_PROGRESS] (storage_agent) Implement EEPROMManager class
 - [IN_PROGRESS] (docs_agent) Maintain style guide and agent docs
 - [TODO] (root_agent) Keep structure spec in sync with repository
-- [TODO] (firmware_agent) Implement main loop in firmware/due/main.ino
-- [TODO] (protocol_agent) Define shared command constants in firmware/shared/commands.h
-- [TODO] (firmware_agent) Handle OUTPUT_ON and OUTPUT_OFF in MenuSystem.cpp
-- [TODO] (docs_agent) Expand docs/impl/main.md and docs/impl/commands.md
+- [IN_PROGRESS] (Stage 21, firmware_agent) Implement main loop in firmware/due/main.ino
+- [IN_PROGRESS] (Stage 21, protocol_agent) Define shared command constants in firmware/shared/commands.h
+- [IN_PROGRESS] (Stage 21, firmware_agent) Handle OUTPUT_ON and OUTPUT_OFF in MenuSystem.cpp
+- [IN_PROGRESS] (Stage 21, docs_agent) Expand docs/impl/main.md and docs/impl/commands.md

--- a/docs/progress/2025-06-18_10-46_root_agent_placeholder_dispatch.md
+++ b/docs/progress/2025-06-18_10-46_root_agent_placeholder_dispatch.md
@@ -1,0 +1,7 @@
+# Root Agent Placeholder Dispatch
+Date: 2025-06-18 10:46 CEST
+
+- Issued firmware_agent prompt for main loop and OUTPUT_ON/OFF handling.
+- Issued protocol_agent prompt for command constant definitions.
+- Issued docs_agent prompt to extend implementation docs.
+- Recorded tasks in TODO.md as Stage 21 and set to IN_PROGRESS.

--- a/docs/prompts/docs_agent/2025-06-18_10-46_expand_impl_docs.md
+++ b/docs/prompts/docs_agent/2025-06-18_10-46_expand_impl_docs.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: docs_agent
+Task: Document firmware loop and commands
+Target File(s): docs/impl/main.md, docs/impl/commands.md
+Related Docs: docs/design/architecture_overview.md, docs/dev_protocols/command_spec.md
+
+### Prompt Body
+Expand `docs/impl/main.md` with a concise description of the firmware control loop, referencing module interactions and update frequency. In `docs/impl/commands.md`, enumerate the command constants defined in `firmware/shared/commands.h` and briefly describe their purpose. Keep docs in English. Log changes to `docs/progress/YYYY-MM-DD_HH-MM_docs_agent.md`.

--- a/docs/prompts/firmware_agent/2025-06-18_10-46_main_loop_output.md
+++ b/docs/prompts/firmware_agent/2025-06-18_10-46_main_loop_output.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: firmware_agent
+Task: Implement main loop and output control
+Target File(s): firmware/due/main.ino, firmware/due/MenuSystem.cpp
+Related Docs: docs/design/architecture_overview.md
+
+### Prompt Body
+Implement the firmware control loop in `firmware/due/main.ino` based on the architecture overview. Instantiate all core modules, set up serial ports, and call `MenuSystem.update()` in `loop()`. In `MenuSystem.cpp`, replace the placeholders under `OUTPUT_ON` and `OUTPUT_OFF` cases with calls that enable or disable the AD9850 output via `DDSDriver`. Keep Hungarian messages for LCD interactions. Log progress to `docs/progress/YYYY-MM-DD_HH-MM_firmware_agent.md`.

--- a/docs/prompts/protocol_agent/2025-06-18_10-46_define_commands.md
+++ b/docs/prompts/protocol_agent/2025-06-18_10-46_define_commands.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: protocol_agent
+Task: Define shared command constants
+Target File(s): firmware/shared/commands.h
+Related Docs: docs/dev_protocols/command_spec.md
+
+### Prompt Body
+Populate `firmware/shared/commands.h` with constant strings for all supported ASCII commands as specified in `command_spec.md`. Include at least frequency set, waveform set, output enable/disable, and configuration load/save commands. Use uppercase names with `CMD_` prefix. Log the update to `docs/progress/YYYY-MM-DD_HH-MM_protocol_agent.md`.


### PR DESCRIPTION
## Summary
- add root agent log for placeholder dispatch
- track Stage 21 tasks in TODO
- add prompts for firmware_agent, protocol_agent and docs_agent

## Testing
- `make test_all` *(fails: missing go dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68527c89fc288322b6cfae81f2d2c5fb