### PR TITLE
Define protocol constants and document

### DIFF
--- a/docs/impl/commands.md
+++ b/docs/impl/commands.md
@@ -1,7 +1,18 @@
 # commands.h
 
-`firmware/shared/commands.h` is meant to hold shared command string constants for
-both the Arduino firmware and the ESP/PC tools. At the moment it contains only a
-placeholder comment. Command definitions should match the ASCII protocol
-specified in `docs/dev_protocols/command_spec.md` once the implementation is
-expanded.
+`firmware/shared/commands.h` defines short ASCII command strings that are shared
+between the firmware and the PC tools. The table below lists the currently
+implemented constants and their meaning.
+
+| Constant | Command | Description | Example Request | Example Response |
+| --- | --- | --- | --- | --- |
+| `CMD_SET_FREQ` | `SF` | Set frequency in Hz as integer | `SF 1000000` | `OK:SETFREQ` |
+| `CMD_GET_FREQ` | `GF` | Query current frequency | `GF` | `OK:FREQ 1000000` |
+| `CMD_SET_WAVE` | `SW` | Set waveform index (0-2) | `SW 1` | `OK:SETWAVE` |
+| `CMD_GET_WAVE` | `GW` | Query current waveform | `GW` | `OK:WAVE 1` |
+| `CMD_OUTPUT_ON` | `ON` | Enable DDS output | `ON` | `OK` |
+| `CMD_OUTPUT_OFF` | `OFF` | Disable DDS output | `OFF` | `OK` |
+
+Commands for saving or loading presets continue to use the words `SAVE` and
+`LOAD`. The constants keep request strings short while responses still use the
+human-readable tokens documented in `command_spec.md`.

--- a/firmware/due/CommandParser.cpp
+++ b/firmware/due/CommandParser.cpp
@@ -1,5 +1,7 @@
 #include "CommandParser.h"
 #include <cstdlib>
+#include <cstring>
+#include "../shared/commands.h"
 
 void CommandParser::begin(DDSDriver& d, EEPROMManager& e) {
     dds = &d;
@@ -10,20 +12,20 @@ String CommandParser::handleCommand(const String& cmd) {
     if (!dds || !eeprom)
         return "ERR:NOT_INIT";
 
-    if (cmd.rfind("SETFREQ", 0) == 0) {
-        uint32_t val = std::strtoul(cmd.substr(7).c_str(), nullptr, 10);
+    if (cmd.rfind(CMD_SET_FREQ, 0) == 0) {
+        uint32_t val = std::strtoul(cmd.substr(strlen(CMD_SET_FREQ) + 1).c_str(), nullptr, 10);
         dds->setFrequency(val);
         return "OK:SETFREQ";
     }
-    if (cmd == "GETFREQ") {
+    if (cmd == CMD_GET_FREQ) {
         return String("OK:FREQ ") + std::to_string(dds->getFrequency());
     }
-    if (cmd.rfind("SETWAVE", 0) == 0) {
-        uint8_t wf = static_cast<uint8_t>(std::strtoul(cmd.substr(7).c_str(), nullptr, 10));
+    if (cmd.rfind(CMD_SET_WAVE, 0) == 0) {
+        uint8_t wf = static_cast<uint8_t>(std::strtoul(cmd.substr(strlen(CMD_SET_WAVE) + 1).c_str(), nullptr, 10));
         dds->setWaveform(wf);
         return "OK:SETWAVE";
     }
-    if (cmd == "GETWAVE") {
+    if (cmd == CMD_GET_WAVE) {
         return String("OK:WAVE ") + std::to_string(dds->getWaveform());
     }
     if (cmd == "SAVE") {

--- a/firmware/shared/commands.h
+++ b/firmware/shared/commands.h
@@ -1,1 +1,17 @@
-// Shared command definitions
+// Shared command definitions for ASCII protocol
+#ifndef SHARED_COMMANDS_H
+#define SHARED_COMMANDS_H
+
+// Frequency control
+#define CMD_SET_FREQ  "SF"  // Set frequency
+#define CMD_GET_FREQ  "GF"  // Query frequency
+
+// Waveform control
+#define CMD_SET_WAVE  "SW"  // Set waveform type
+#define CMD_GET_WAVE  "GW"  // Query waveform
+
+// Output enable/disable
+#define CMD_OUTPUT_ON  "ON"
+#define CMD_OUTPUT_OFF "OFF"
+
+#endif // SHARED_COMMANDS_H

--- a/pc/cli/ddsctl.py
+++ b/pc/cli/ddsctl.py
@@ -2,6 +2,9 @@
 import argparse
 import serial
 
+CMD_SET_FREQ = "SF"
+CMD_GET_FREQ = "GF"
+
 
 def send(port, cmd):
     port.write((cmd + "\n").encode())
@@ -29,9 +32,9 @@ def main():
 
     with serial.Serial(args.port, 115200, timeout=2) as ser:
         if args.cmd == "set-freq":
-            resp = send(ser, f"SETFREQ {args.freq}")
+            resp = send(ser, f"{CMD_SET_FREQ} {args.freq}")
         elif args.cmd == "get-freq":
-            resp = send(ser, "GETFREQ")
+            resp = send(ser, CMD_GET_FREQ)
         elif args.cmd == "preset-save":
             resp = send(ser, f"SAVE {args.slot}")
         else:  # preset-load

--- a/pc/gui/MainWindow.go
+++ b/pc/gui/MainWindow.go
@@ -6,6 +6,13 @@ import (
     "fyne.io/fyne/v2/widget"
 )
 
+const (
+    cmdSetFreq = "SF"
+    cmdGetFreq = "GF"
+    cmdSetWave = "SW"
+    cmdGetWave = "GW"
+)
+
 func main() {
     a := app.New()
     w := a.NewWindow("DDS Controller")
@@ -33,15 +40,15 @@ func main() {
     currentWave := widget.NewLabel("Wave: -")
 
     setBtn := widget.NewButton("Set", func() {
-        bridge.Send("SETFREQ " + freqEntry.Text)
-        bridge.Send("SETWAVE " + waveSelect.Selected)
+        bridge.Send(cmdSetFreq + " " + freqEntry.Text)
+        bridge.Send(cmdSetWave + " " + waveSelect.Selected)
     })
 
     readBtn := widget.NewButton("Read", func() {
-        if resp, err := bridge.Send("GETFREQ"); err == nil {
+        if resp, err := bridge.Send(cmdGetFreq); err == nil {
             currentFreq.SetText(resp)
         }
-        if resp, err := bridge.Send("GETWAVE"); err == nil {
+        if resp, err := bridge.Send(cmdGetWave); err == nil {
             currentWave.SetText(resp)
         }
     })

--- a/tests/cli/test_ddsctl.py
+++ b/tests/cli/test_ddsctl.py
@@ -9,7 +9,7 @@ class FakeSerial:
     def write(self, data):
         self.last = data
     def readline(self):
-        if b"SETFREQ" in self.last:
+        if b"SF" in self.last:
             return b"OK:SETFREQ\n"
         return b"OK:FREQ 1000000\n"
     def __enter__(self):

--- a/tests/firmware/test_ddsdriver.cpp
+++ b/tests/firmware/test_ddsdriver.cpp
@@ -15,7 +15,7 @@ int main() {
     EEPROMManager e;
     CommandParser p;
     p.begin(d, e);
-    assert(p.handleCommand("SETFREQ 12345") == "OK:SETFREQ");
+    assert(p.handleCommand("SF 12345") == "OK:SETFREQ");
     assert(d.getFrequency() == 12345u);
 
     LiquidCrystal lcd(0,0,0,0,0,0);


### PR DESCRIPTION
## Summary
- implement short ASCII command constants in `commands.h`
- use the new constants inside `CommandParser`
- update CLI and GUI tools to send the short codes
- adjust unit tests for the protocol change
- document all command constants and examples

## Testing
- `make test_all` *(fails: missing go modules)*

------
https://chatgpt.com/codex/tasks/task_e_68527f47ec148322b4c330472a4753bb