### PR TITLE
Add test coverage log and TODO updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,9 @@
 - [IN_PROGRESS] (Stage 21, protocol_agent) Define shared command constants in firmware/shared/commands.h
 - [IN_PROGRESS] (Stage 21, firmware_agent) Handle OUTPUT_ON and OUTPUT_OFF in MenuSystem.cpp
 - [IN_PROGRESS] (Stage 21, docs_agent) Expand docs/impl/main.md and docs/impl/commands.md
+- [TEST] (pc_agent) Add test for invalid frequency input in ddsctl
+- [TEST] (pc_agent) Add tests for preset-save and preset-load commands
+- [TEST] (firmware_agent) Test EEPROMManager read/write and preset functions
+- [TEST] (firmware_agent) Expand CommandParser coverage for all commands
+- [TEST] (firmware_agent) Verify MenuSystem actions for OUTPUT_ON and OUTPUT_OFF
+- [TEST] (pc_agent) Add GUI tests for Set and Read button callbacks

--- a/docs/progress/2025-06-18_11-20_test_coverage_report.md
+++ b/docs/progress/2025-06-18_11-20_test_coverage_report.md
@@ -1,0 +1,31 @@
+# Test Coverage Report
+Date: 2025-06-18 11:20 CEST
+
+## Coverage Summary
+
+- `go test ./...` failed due to blocked module downloads. No Go coverage produced.
+- `pytest` suite executed 2 CLI tests successfully.
+- Firmware C++ test built and ran without output; no coverage metric available.
+
+## Untested Functions
+
+### CLI
+- `preset-save` and `preset-load` branches in `ddsctl.main`
+- Invalid frequency handling in `ddsctl.main` and `send` errors
+
+### Firmware
+- All `EEPROMManager` routines (save/load/preset)
+- `CommandParser` commands: `GF`, `SW`, `GW`, `SAVE`, `LOAD`, `STATUS`, `VERSION`
+- `MenuSystem` actions for output control and preset management
+
+### GUI
+- `SerialBridge` error paths and close semantics
+- Button callbacks for Set/Read operations
+
+## Recommendations
+
+- Extend CLI tests to cover presets and invalid input.
+- Mock EEPROM to test read/write logic.
+- Cover remaining `CommandParser` branches and MenuSystem actions.
+- Use `fyne/test` for GUI Set/Read buttons once dependencies are available.
+- Provide vendored Go modules to unblock CI coverage.


### PR DESCRIPTION
## Summary
- document test coverage status and missing cases
- add testing tasks to TODO

## Testing
- `pytest -q tests/cli`
- `make run_firmware_tests`
- `go test ./... -coverprofile=coverage.out` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852848eef5c8322ab886994c7febd21