### PR TITLE
Add test coverage docs

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -1,0 +1,1 @@
+<html><body><p>No coverage data generated due to blocked dependencies.</p></body></html>

--- a/coverage.out
+++ b/coverage.out
@@ -1,0 +1,1 @@
+mode: set

--- a/docs/progress/2025-06-18_11-42_test_coverage_report.md
+++ b/docs/progress/2025-06-18_11-42_test_coverage_report.md
@@ -1,0 +1,7 @@
+# Test Coverage Agent Log
+Date: 2025-06-18 11:42 CEST
+
+- Attempted to run `go test ./... -coverprofile=coverage.out` from `tests/gui`.
+- Module downloads failed due to blocked access to storage.googleapis.com.
+- Created placeholder `coverage.out` and `coverage.html`.
+- Documented the issue in `docs/tests/test_coverage.md`.

--- a/docs/tests/test_coverage.md
+++ b/docs/tests/test_coverage.md
@@ -1,0 +1,17 @@
+# Go Test Coverage
+
+This report summarizes the latest attempt to measure unit test coverage for the Go components of the project.
+
+## Coverage Attempt
+
+`go test ./... -coverprofile=coverage.out`
+
+Execution failed because the module dependencies (for the Fyne GUI) could not be downloaded in the current environment. The proxy blocked requests to `storage.googleapis.com` which hosts the modules.
+
+No coverage data was produced. A placeholder `coverage.out` file is kept for reference.
+
+## Next Steps
+
+- Provide offline vendored copies of third party packages so tests can run without internet access.
+- Increase test coverage by adding unit tests for the GUI logic and any future Go packages.
+- Integrate coverage generation into CI once dependencies are resolved.


### PR DESCRIPTION
## Summary
- provide placeholder coverage.out and coverage.html
- document failed coverage attempt in docs/tests/test_coverage.md
- log the event in docs/progress/2025-06-18_11-42_test_coverage_report.md

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852895ca9f08322b54a13416f03c260