### PR TITLE
Update coverage docs

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -1,1 +1,108 @@
-<html><body><p>No coverage data generated due to blocked dependencies.</p></body></html>
+
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Go Coverage Report</title>
+		<style>
+			body {
+				background: black;
+				color: rgb(80, 80, 80);
+			}
+			body, pre, #legend span {
+				font-family: Menlo, monospace;
+				font-weight: bold;
+			}
+			#topbar {
+				background: black;
+				position: fixed;
+				top: 0; left: 0; right: 0;
+				height: 42px;
+				border-bottom: 1px solid rgb(80, 80, 80);
+			}
+			#content {
+				margin-top: 50px;
+			}
+			#nav, #legend {
+				float: left;
+				margin-left: 10px;
+			}
+			#legend {
+				margin-top: 12px;
+			}
+			#nav {
+				margin-top: 10px;
+			}
+			#legend span {
+				margin: 0 5px;
+			}
+			.cov0 { color: rgb(192, 0, 0) }
+.cov1 { color: rgb(128, 128, 128) }
+.cov2 { color: rgb(116, 140, 131) }
+.cov3 { color: rgb(104, 152, 134) }
+.cov4 { color: rgb(92, 164, 137) }
+.cov5 { color: rgb(80, 176, 140) }
+.cov6 { color: rgb(68, 188, 143) }
+.cov7 { color: rgb(56, 200, 146) }
+.cov8 { color: rgb(44, 212, 149) }
+.cov9 { color: rgb(32, 224, 152) }
+.cov10 { color: rgb(20, 236, 155) }
+
+		</style>
+	</head>
+	<body>
+		<div id="topbar">
+			<div id="nav">
+				<select id="files">
+				
+				</select>
+			</div>
+			<div id="legend">
+				<span>not tracked</span>
+			
+				<span class="cov0">no coverage</span>
+				<span class="cov1">low coverage</span>
+				<span class="cov2">*</span>
+				<span class="cov3">*</span>
+				<span class="cov4">*</span>
+				<span class="cov5">*</span>
+				<span class="cov6">*</span>
+				<span class="cov7">*</span>
+				<span class="cov8">*</span>
+				<span class="cov9">*</span>
+				<span class="cov10">high coverage</span>
+			
+			</div>
+		</div>
+		<div id="content">
+		
+		</div>
+	</body>
+	<script>
+	(function() {
+		var files = document.getElementById('files');
+		var visible;
+		files.addEventListener('change', onChange, false);
+		function select(part) {
+			if (visible)
+				visible.style.display = 'none';
+			visible = document.getElementById(part);
+			if (!visible)
+				return;
+			files.value = part;
+			visible.style.display = 'block';
+			location.hash = part;
+		}
+		function onChange() {
+			select(files.value);
+			window.scrollTo(0, 0);
+		}
+		if (location.hash != "") {
+			select(location.hash.substr(1));
+		}
+		if (!visible) {
+			select("file0");
+		}
+	})();
+	</script>
+</html>

--- a/coverage.out
+++ b/coverage.out
@@ -1,1 +1,2 @@
 mode: set
+# attempt 2025-06-18 12:02

--- a/docs/progress/2025-06-18_12-02_test_coverage_report.md
+++ b/docs/progress/2025-06-18_12-02_test_coverage_report.md
@@ -1,0 +1,6 @@
+# Test Coverage Agent Log
+Date: 2025-06-18 12:02 CEST
+
+- Ran `go test ./... -coverprofile=coverage.out`.
+- Module downloads blocked again, so `coverage.out` only contains the header line.
+- Generated `coverage.html` with `go tool cover` (shows 0% coverage).

--- a/docs/tests/test_coverage.md
+++ b/docs/tests/test_coverage.md
@@ -6,9 +6,9 @@ This report summarizes the latest attempt to measure unit test coverage for the 
 
 `go test ./... -coverprofile=coverage.out`
 
-Execution failed because the module dependencies (for the Fyne GUI) could not be downloaded in the current environment. The proxy blocked requests to `storage.googleapis.com` which hosts the modules.
+Both the original attempt and a second run on **2025‑06‑18 12:02 CEST** failed because the required modules (for the Fyne GUI) could not be downloaded. The proxy blocked requests to `storage.googleapis.com`.
 
-No coverage data was produced. A placeholder `coverage.out` file is kept for reference.
+As a result, `coverage.out` only contains the header line and the overall coverage reported by `go tool cover` is **0%**.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- log Go test coverage attempt and generated empty report
- adjust docs/tests/test_coverage.md with latest results
- regenerate `coverage.html` with go tool
- add progress log

## Testing
- `make test_cli`
- `make run_firmware_tests`
- `go tool cover -func=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68528e672cb483228fd9468dab6ebf7d