### PR TITLE
Add full audit report for DDS-Controller

### DIFF
--- a/docs/reports/2025-06-18_dds_controller_audit.md
+++ b/docs/reports/2025-06-18_dds_controller_audit.md
@@ -1,0 +1,27 @@
+# DDS-Controller Full Audit – 2025-06-18
+
+## Summary
+This audit reviews repository consistency, progress logging and outstanding tasks. The project mostly follows the file-driven agent model described in `AGENTS.md`, but several directories lack documentation and some milestones are outdated.
+
+## Findings
+| Area | Issue | Agent(s) | Suggested Action |
+| --- | --- | --- | --- |
+| AGENTS & Milestones | `MILESTONES.md` still lists Windows packaging and Web UI without progress logs | root_agent | Update or close obsolete milestones |
+| TODO list | Test tasks and structure sync remain open without clear progress | root_agent, pc_agent, firmware_agent | Mark completed items and dispatch remaining tests |
+| Documentation | Firmware, ESP and PC directories lack README files | docs_agent | Add brief READMEs per directory |
+| Progress Logs | Logs exist but some tasks have no explicit log link (e.g. Windows packaging) | timeline_agent | Ensure every TODO item has corresponding log |
+| Testing | GUI tests fail due to blocked Go module downloads | pc_agent | Add offline stubs or mark tests skipped in CI |
+
+## Notes
+- Coverage report shows ~30% unit test coverage; GUI tests blocked by network restrictions.
+- `incomplete_implementations.md` still references pending test entries.
+- Many `mocks/` headers contain minimal stubs which should be documented.
+
+## References
+- Agents overview in `AGENTS.md` lines 34-83
+- TODO list entries in `TODO.md` lines 1-13
+- Milestones in `MILESTONES.md` lines 1-10
+- Incomplete implementations report lines 1-20
+- Previous audit log `docs/progress/2025-06-18_10-16_root_agent_full_audit.md` lines 5-42
+- Coverage details in `docs/testing/coverage_report.md` lines 1-13
+


### PR DESCRIPTION
## Summary
- log repo audit results in docs/reports/2025-06-18_dds_controller_audit.md

## Testing
- `make test_all` *(fails: Go module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68529e4d72e883228ee2e740c93f6401