### PR TITLE
Update milestones and dispatch tests

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,10 +1,10 @@
 # Development Milestones
 
-- [x] Initial structure setup
-- [x] Basic module stubs implemented
-- [x] Firmware + CLI prototype
-- [ ] Windows packaging for Qt GUI
-- [x] Version history initiated
-- [ ] ESP protocol implementation
-- [ ] Web UI
-- [ ] EEPROM preset handling
+- [x] Initial structure setup ([log](docs/progress/2025-06-18_05-29-50_root_structure_sync.md))
+- [x] Basic module stubs implemented ([log](docs/progress/2025-06-18_16-55_root_agent_remediation.md))
+- [x] Firmware + CLI prototype ([log](docs/progress/2025-06-18_09-10-00_functional_stage.md))
+- [x] ~~Windows packaging for Qt GUI~~ *(canceled)* ([note](docs/progress/2025-06-18_08-24_structure_sync.md))
+- [x] Version history initiated ([log](docs/progress/2025-06-18_16-55_root_agent_remediation.md))
+- [ ] ESP protocol implementation ([log](docs/progress/2025-06-18_09-10-00_functional_stage.md))
+- [x] ~~Web UI~~ *(canceled)* ([note](docs/progress/2025-06-18_10-33_placeholder_audit.md))
+- [ ] EEPROM preset handling ([log](docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md))

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,13 @@
 - [DONE] (storage_agent) Implement EEPROMManager class
 - [IN_PROGRESS] (docs_agent) Maintain style guide and agent docs
-- [TODO] (root_agent) Keep structure spec in sync with repository
+- [DONE] (root_agent) Keep structure spec in sync with repository (see docs/progress/2025-06-18_08-24_structure_sync.md)
 - [DONE] (Stage 21, firmware_agent) Implement main loop in firmware/due/main.ino
 - [DONE] (Stage 21, protocol_agent) Define shared command constants in firmware/shared/commands.h
 - [DONE] (Stage 21, firmware_agent) Handle OUTPUT_ON and OUTPUT_OFF in MenuSystem.cpp
 - [DONE] (Stage 21, docs_agent) Expand docs/impl/main.md and docs/impl/commands.md
-- [TEST] (pc_agent) Add test for invalid frequency input in ddsctl
-- [TEST] (pc_agent) Add tests for preset-save and preset-load commands
-- [TEST] (firmware_agent) Test EEPROMManager read/write and preset functions
-- [TEST] (firmware_agent) Expand CommandParser coverage for all commands
-- [TEST] (firmware_agent) Verify MenuSystem actions for OUTPUT_ON and OUTPUT_OFF
-- [TEST] (pc_agent) Add GUI tests for Set and Read button callbacks
+- [DISPATCHED] (pc_agent) Add test for invalid frequency input in ddsctl – see docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md
+- [DISPATCHED] (pc_agent) Add tests for preset-save and preset-load commands – see docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md
+- [DISPATCHED] (firmware_agent) Test EEPROMManager read/write and preset functions – see docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
+- [DISPATCHED] (firmware_agent) Expand CommandParser coverage for all commands – see docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
+- [DISPATCHED] (firmware_agent) Verify MenuSystem actions for OUTPUT_ON and OUTPUT_OFF – see docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
+- [DISPATCHED] (pc_agent) Add GUI tests for Set and Read button callbacks – see docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md

--- a/docs/progress/2025-06-18_13-30_timeline_agent_dispatch.md
+++ b/docs/progress/2025-06-18_13-30_timeline_agent_dispatch.md
@@ -1,0 +1,5 @@
+# Timeline Agent Log
+Date: 2025-06-18 13:30 CEST
+
+- Dispatched firmware test prompt `2025-06-18_13-20_firmware_tests.md` to `firmware_agent`.
+- Dispatched PC test prompt `2025-06-18_13-25_cli_gui_tests.md` to `pc_agent`.

--- a/docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
+++ b/docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: firmware_agent
+Task: Expand firmware unit tests
+Target File(s): tests/firmware/test_eeprommanager.cpp, tests/firmware/test_commandparser.cpp, tests/firmware/test_menusystem.cpp
+Related Docs: docs/design/architecture_overview.md, docs/dev_protocols/command_spec.md
+
+### Prompt Body
+Implement Catch2-based tests covering EEPROMManager save/load operations, CommandParser dispatch for all supported commands, and MenuSystem actions for OUTPUT_ON and OUTPUT_OFF. Reuse existing mocks and helper functions. Log results to `docs/progress/YYYY-MM-DD_HH-MM-SS_firmware_agent.md`.

--- a/docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md
+++ b/docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: pc_agent
+Task: Add CLI and GUI tests
+Target File(s): tests/cli/test_ddsctl.py, tests/gui/test_mainwindow.go
+Related Docs: docs/design/pc_ui_mockups.md
+
+### Prompt Body
+Create pytest cases for `ddsctl.py` validating invalid frequency input and preset-save/preset-load commands. Extend `test_mainwindow.go` with Fyne-based tests for Set and Read button callbacks using a mock SerialBridge. Log progress to `docs/progress/YYYY-MM-DD_HH-MM-SS_pc_agent.md`.


### PR DESCRIPTION
## Summary
- close obsolete milestones and link to progress logs
- mark structure sync done in TODO
- dispatch test tasks to pc_agent and firmware_agent via new prompts
- log dispatch with timeline agent

## Testing
- `make test_all` *(fails: forbidden download from storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6852a1663d0c83228522600ab47a86f8