### PR TITLE
Add missing progress logs for TODO tasks

### DIFF
--- a/docs/progress/2025-06-18_14-22-timeline_agent.md
+++ b/docs/progress/2025-06-18_14-22-timeline_agent.md
@@ -1,0 +1,6 @@
+# Timeline Agent Log
+Date: 2025-06-18 14:22 CEST
+
+- Task: Define shared command constants in `firmware/shared/commands.h`.
+- Executed by: `protocol_agent`.
+- Status: completed (previous progress log missing).

--- a/docs/progress/2025-06-18_14-23-timeline_agent.md
+++ b/docs/progress/2025-06-18_14-23-timeline_agent.md
@@ -1,0 +1,6 @@
+# Timeline Agent Log
+Date: 2025-06-18 14:23 CEST
+
+- Task: Expand `docs/impl/main.md` and `docs/impl/commands.md` with implementation details.
+- Executed by: `docs_agent`.
+- Status: completed (previous progress log missing).


### PR DESCRIPTION
## Summary
- backfill timeline entries for command constants and docs expansion

## Testing
- `make test_all` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852aefb42448322a24349ce1333335f