### PR TITLE
Close preset milestone and update TODO

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -7,4 +7,4 @@
 - [x] Version history initiated ([log](docs/progress/2025-06-18_16-55_root_agent_remediation.md))
 - [ ] ESP protocol implementation ([log](docs/progress/2025-06-18_09-10-00_functional_stage.md))
 - [x] ~~Web UI~~ *(canceled)* ([note](docs/progress/2025-06-18_10-33_placeholder_audit.md))
-- [ ] EEPROM preset handling ([log](docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md))
+- [x] EEPROM preset handling ([log](docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md))

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 - [DONE] (storage_agent) Implement EEPROMManager class
-- [IN_PROGRESS] (docs_agent) Maintain style guide and agent docs
+- [DONE] (docs_agent) Maintain style guide and agent docs (see docs/progress/2025-06-18_16-55_root_agent_remediation.md)
 - [DONE] (root_agent) Keep structure spec in sync with repository (see docs/progress/2025-06-18_08-24_structure_sync.md)
 - [DONE] (Stage 21, firmware_agent) Implement main loop in firmware/due/main.ino
 - [DONE] (Stage 21, protocol_agent) Define shared command constants in firmware/shared/commands.h
@@ -11,3 +11,6 @@
 - [DISPATCHED] (firmware_agent) Expand CommandParser coverage for all commands – see docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
 - [DISPATCHED] (firmware_agent) Verify MenuSystem actions for OUTPUT_ON and OUTPUT_OFF – see docs/prompts/firmware_agent/2025-06-18_13-20_firmware_tests.md
 - [DISPATCHED] (pc_agent) Add GUI tests for Set and Read button callbacks – see docs/prompts/pc_agent/2025-06-18_13-25_cli_gui_tests.md
+- [TODO] (pc_agent) Provide offline stubs for GUI tests or skip them in CI (see docs/progress/2025-06-18_11-20_test_coverage_report.md)
+- [TODO] (docs_agent) Document firmware/due/mocks usage and limitations (README)
+- [TODO] (test_coverage_agent) Audit untested modules and design coverage plan (see docs/reports/incomplete_implementations.md)

--- a/docs/progress/2025-06-18_14-14-03_final_recommendation_log.md
+++ b/docs/progress/2025-06-18_14-14-03_final_recommendation_log.md
@@ -1,0 +1,19 @@
+# Final Recommendation Log – 2025-06-18 14:14:03 CEST
+
+## Summary
+This log records the actions taken by `root_agent` to close out the remaining recommendations from the 2025‑06‑18 audit.
+
+### Milestones
+- Marked **EEPROM preset handling** milestone as complete.
+- Confirmed **ESP protocol implementation** is still open and linked to existing progress log.
+
+### TODO Updates
+- Marked docs agent style guide task as **DONE** with reference to remediation log.
+- Added new tasks for GUI test stubs, mock documentation and overall coverage planning.
+
+### Documentation
+- Verified that `firmware/`, `pc/` and `firmware/esp/` each contain a `README.md`.
+
+### Testing
+- Executed `make test_all`; firmware and CLI tests pass. GUI tests fall back to stub mode due to blocked network access.
+


### PR DESCRIPTION
## Summary
- close milestone for EEPROM preset handling
- mark docs agent style guide task done
- add TODOs for GUI test stubs and mock docs
- log final recommendation actions

## Testing
- `make test_all`

------
https://chatgpt.com/codex/tasks/task_e_6852c8b6f00883229de0f5809535d324