### PR TITLE
Dispatch milestone v0.4.0 tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,3 +31,4 @@
 - [DISPATCHED] (pc_agent) Stub ESP responses and extend GUI unit tests
 - [DISPATCHED] (timeline_agent) Record coverage progress and version tags
 - [DISPATCHED] (docs_agent) Prepare CHANGELOG.md for v0.4.0
+- [DISPATCHED] (timeline_agent) Log milestone v0.4.0 kickoff

--- a/docs/progress/2025-06-18_17-43-41_root_agent_v0.4.0_dispatch.md
+++ b/docs/progress/2025-06-18_17-43-41_root_agent_v0.4.0_dispatch.md
@@ -1,0 +1,15 @@
+# Milestone v0.4.0 Dispatch – 2025-06-18 17:43 CEST
+
+Dispatched milestone tasks for v0.4.0 to all active agents. Prompt files were created under `docs/prompts/*/2025-06-18_17-43-41_v0.4.0_plan.md`.
+
+## Assigned Prompts
+- esp_agent – WiFi bridge and heartbeat
+- protocol_agent – command bridge specification
+- firmware_agent – Due integration for ESP bridge
+- ui_agent – minimal Web UI
+- docs_agent – Web UI docs and CHANGELOG
+- test_coverage_agent – firmware↔ESP integration tests
+- pc_agent – GUI tests with ESP stubs
+- timeline_agent – record milestone kickoff
+
+`TODO.md` updated with a kickoff task for `timeline_agent`.

--- a/docs/prompts/docs_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/docs_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: docs_agent
+Task: Document Web UI and ESP configuration; prepare CHANGELOG
+Target File(s): docs/impl/web_ui.md, CHANGELOG.md
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Document the setup and usage of the Web UI and ESP WiFi configuration in `docs/impl/web_ui.md`. Also start `CHANGELOG.md` for version v0.4.0 summarizing notable changes. Log progress to `docs/progress/2025-06-18_17-43-41_docs_agent_v0.4.0.md`.

--- a/docs/prompts/esp_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/esp_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: esp_agent
+Task: Implement ESP WiFi bridge for v0.4.0
+Target File(s): firmware/esp/main.ino
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Implement bidirectional UART communication with the Arduino Due and add Wi-Fi configuration handling. Include a periodic heartbeat as described in `protocol_layers.md`. Log all progress to `docs/progress/2025-06-18_17-43-41_esp_agent_v0.4.0.md`.

--- a/docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: firmware_agent
+Task: Integrate ESP bridge with Arduino Due
+Target File(s): firmware/due/main.ino, firmware/due/CommandParser.cpp
+Related Docs: docs/design/architecture_overview.md
+
+### Prompt Body
+Add serial handling for the ESP bridge in `main.ino` and extend `CommandParser.cpp` to route commands from the ESP. Ensure non-blocking loops and log actions to `docs/progress/2025-06-18_17-43-41_firmware_agent_v0.4.0.md`.

--- a/docs/prompts/pc_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/pc_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: pc_agent
+Task: Stub ESP responses and extend GUI tests
+Target File(s): tests/gui/test_mainwindow.go
+Related Docs: docs/design/pc_ui_mockups.md
+
+### Prompt Body
+Update GUI tests to simulate ESP responses for frequency read/set actions. Use the existing mock serial bridge. Log progress to `docs/progress/2025-06-18_17-43-41_pc_agent_v0.4.0.md`.

--- a/docs/prompts/protocol_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/protocol_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: protocol_agent
+Task: Define ESP command bridge and heartbeat messages
+Target File(s): protocol/rest/endpoints.md
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Document the REST endpoints and serial bridge messages for ESP communication. Include a heartbeat description and command examples. Save the specification to `protocol/rest/endpoints.md` and log progress to `docs/progress/2025-06-18_17-43-41_protocol_agent_v0.4.0.md`.

--- a/docs/prompts/test_coverage_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/test_coverage_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: test_coverage_agent
+Task: Add integration tests for firmware and ESP
+Target File(s): tests/integration/test_firmware_esp.py
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Create integration tests covering the interaction between the Arduino firmware and the ESP bridge. Use mocks where hardware is unavailable. Record results to `docs/progress/2025-06-18_17-43-41_test_coverage_agent_v0.4.0.md`.

--- a/docs/prompts/timeline_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/timeline_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: timeline_agent
+Task: Record milestone v0.4.0 kickoff and track progress
+Target File(s): docs/versions/v0.4.0.md
+Related Docs: docs/AGENTS.md
+
+### Prompt Body
+Create `docs/versions/v0.4.0.md` noting the milestone kickoff date and referencing dispatched tasks. Update progress logs as work proceeds. Log this initiation to `docs/progress/2025-06-18_17-43-41_timeline_agent_v0.4.0.md`.

--- a/docs/prompts/ui_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+++ b/docs/prompts/ui_agent/2025-06-18_17-43-41_v0.4.0_plan.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: ui_agent
+Task: Host minimal Web UI for DDS control
+Target File(s): firmware/esp/web_ui/index.html
+Related Docs: docs/design/project_structure.md
+
+### Prompt Body
+Create a simple HTML page under `firmware/esp/web_ui/` that allows frequency read and set operations via the ESP REST API. Keep user-facing text in Hungarian. Log progress to `docs/progress/2025-06-18_17-43-41_ui_agent_v0.4.0.md`.

--- a/docs/prompts/ui_agent/README.md
+++ b/docs/prompts/ui_agent/README.md
@@ -1,0 +1,1 @@
+# ui_agent


### PR DESCRIPTION
## Summary
- add v0.4.0 dispatch prompts for all agents
- log milestone kickoff and update TODO

## Testing
- `make test_all` *(fails to download fyne but falls back to stubbed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852dde00e4883228ccd8e9d9a0029ef