### PR TITLE
Add root audit log and coordination prompts

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -9,3 +9,12 @@
 - [x] ~~Web UI~~ *(canceled)* ([note](docs/progress/2025-06-18_10-33_placeholder_audit.md))
 - [x] EEPROM preset handling ([log](docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md))
 - [PLANNED] Milestone v0.4.0 kickoff – expand remote control, web UI and testing
+
+## v0.4.0 – Remote Control Expansion (PLANNED)
+- Kickoff: 2025-06-18
+- Goals:
+  - Implement ESP8266 WiFi bridge with heartbeat
+  - Provide minimal Web UI
+  - Extend firmware↔ESP integration tests
+  - Start project CHANGELOG
+- Related Dispatch: [root_agent](docs/progress/2025-06-18_17-43-41_root_agent_v0.4.0_dispatch.md)

--- a/TODO.md
+++ b/TODO.md
@@ -32,3 +32,6 @@
 - [DISPATCHED] (timeline_agent) Record coverage progress and version tags
 - [DISPATCHED] (docs_agent) Prepare CHANGELOG.md for v0.4.0
 - [DISPATCHED] (timeline_agent) Log milestone v0.4.0 kickoff
+
+- [DISPATCHED] (esp_agent, protocol_agent) Coordinate serial bridge message format and heartbeat timing
+- [DISPATCHED] (ui_agent, pc_agent) Align Web UI controls with Qt GUI

--- a/docs/progress/2025-06-18_17-52_root_agent_v0.4.0_kickoff_audit.md
+++ b/docs/progress/2025-06-18_17-52_root_agent_v0.4.0_kickoff_audit.md
@@ -1,0 +1,31 @@
+# Milestone v0.4.0 Kickoff Audit – 2025-06-18 17:52 CEST
+
+Performed a post-kickoff audit for milestone **v0.4.0**. Verified prompt
+availability, TODO entries, and progress log readiness across all dispatched
+agents.
+
+## Prompt Check
+| Agent | Prompt File | Progress Log |
+|-------|-------------|--------------|
+| esp_agent | docs/prompts/esp_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| protocol_agent | docs/prompts/protocol_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| firmware_agent | docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| ui_agent | docs/prompts/ui_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| docs_agent | docs/prompts/docs_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| test_coverage_agent | docs/prompts/test_coverage_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| pc_agent | docs/prompts/pc_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+| timeline_agent | docs/prompts/timeline_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *missing* |
+
+## TODO & Milestones
+- Verified v0.4.0 tasks present in `TODO.md`.
+- Added coordination tasks for ESP↔protocol and UI↔PC agents.
+- Created milestone section for v0.4.0 in `MILESTONES.md`.
+
+## Coordination
+New prompts instructing cross-agent synchronization were placed under:
+- `docs/prompts/esp_agent/2025-06-18_17-52_coord_protocol_agent.md`
+- `docs/prompts/protocol_agent/2025-06-18_17-52_coord_esp_agent.md`
+- `docs/prompts/ui_agent/2025-06-18_17-52_coord_pc_agent.md`
+- `docs/prompts/pc_agent/2025-06-18_17-52_coord_ui_agent.md`
+
+Agents without progress logs must log their planning status before implementation begins.

--- a/docs/prompts/esp_agent/2025-06-18_17-52_coord_protocol_agent.md
+++ b/docs/prompts/esp_agent/2025-06-18_17-52_coord_protocol_agent.md
@@ -1,0 +1,10 @@
+### Prompt Metadata
+Agent: esp_agent
+Task: Coordinate message format with protocol_agent
+Target File(s): docs/design/protocol_layers.md
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Work with `protocol_agent` to finalise the serial bridge message format and
+heartbeat timings. Document the agreed format in `protocol_layers.md` and log
+the session to `docs/progress/2025-06-18_17-52_esp_agent_protocol_coord.md`.

--- a/docs/prompts/pc_agent/2025-06-18_17-52_coord_ui_agent.md
+++ b/docs/prompts/pc_agent/2025-06-18_17-52_coord_ui_agent.md
@@ -1,0 +1,10 @@
+### Prompt Metadata
+Agent: pc_agent
+Task: Sync GUI with ui_agent
+Target File(s): pc/gui/main_window.cpp
+Related Docs: docs/design/pc_ui_mockups.md
+
+### Prompt Body
+Work with `ui_agent` to ensure GUI actions mirror the Web UI endpoints. Adjust
+the Qt GUI where needed and log progress to
+`docs/progress/2025-06-18_17-52_pc_ui_coord.md`.

--- a/docs/prompts/protocol_agent/2025-06-18_17-52_coord_esp_agent.md
+++ b/docs/prompts/protocol_agent/2025-06-18_17-52_coord_esp_agent.md
@@ -1,0 +1,10 @@
+### Prompt Metadata
+Agent: protocol_agent
+Task: Align serial bridge with esp_agent
+Target File(s): docs/design/protocol_layers.md
+Related Docs: docs/design/protocol_layers.md
+
+### Prompt Body
+Collaborate with `esp_agent` to specify the UART bridge packet structure and
+heartbeat. Update `protocol_layers.md` accordingly and log results to
+`docs/progress/2025-06-18_17-52_protocol_agent_esp_coord.md`.

--- a/docs/prompts/ui_agent/2025-06-18_17-52_coord_pc_agent.md
+++ b/docs/prompts/ui_agent/2025-06-18_17-52_coord_pc_agent.md
@@ -1,0 +1,10 @@
+### Prompt Metadata
+Agent: ui_agent
+Task: Coordinate controls with pc_agent
+Target File(s): firmware/esp/web_ui/index.html
+Related Docs: docs/design/pc_ui_mockups.md
+
+### Prompt Body
+Sync control labels and REST endpoints with `pc_agent` so GUI and Web UI remain
+consistent. Update the web page accordingly and log to
+`docs/progress/2025-06-18_17-52_ui_pc_coord.md`.


### PR DESCRIPTION
## Summary
- perform root agent audit after v0.4.0 kickoff
- add cross-agent coordination prompts
- add TODO entries for coordination
- append v0.4.0 milestone section

## Testing
- `make test_all` *(fails: network access needed for Go modules)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0288db08322876982de4c23d057