### PR TITLE
Add ESP protocol sync spec

### DIFF
--- a/docs/design/project_structure.md
+++ b/docs/design/project_structure.md
@@ -65,6 +65,8 @@
 │   ├── impl/                       # Implementation notes per module
 │   │   ├── DDSDriver.md
 │   │   └── ...
+│   ├── spec/                       # Interface specifications
+│   │   └── esp_protocol_sync.md
 │   └── prompts/                    # Generated prompts per agent
 │       ├── firmware_agent/
 │       ├── pc_agent/

--- a/docs/progress/2025-06-18_18-10-00_esp_protocol_sync.md
+++ b/docs/progress/2025-06-18_18-10-00_esp_protocol_sync.md
@@ -1,0 +1,6 @@
+# ESP↔Protocol Sync Log
+Date: 2025-06-18 18:10:00 CEST
+
+- Created `docs/spec/esp_protocol_sync.md` summarising ESP behaviour and protocol commands.
+- Updated `docs/design/project_structure.md` to include the new spec directory.
+- Verified tests via `make test_all` (GUI tests used stub mode).

--- a/docs/spec/esp_protocol_sync.md
+++ b/docs/spec/esp_protocol_sync.md
@@ -1,0 +1,51 @@
+# esp_protocol_sync.md – ESP8266 Protocol Synchronisation
+
+> Last updated: 2025-06-18
+> Maintainer: esp_agent & protocol_agent
+
+This document aligns the ESP8266 firmware behaviour with the ASCII protocol
+definitions for DDS-Controller milestone **v0.4.0**.
+
+## ESP subsystem summary
+- **File**: `firmware/esp/main.ino`
+- **Role**: UART bridge between the Arduino Due and optional Wi-Fi API.
+- **Stack**: two UART ports at 115200 8N1, planned HTTP endpoints
+  `/api/frequency`, `/api/status` and `/api/save`.
+- **Framing**: lines terminated by `\n`; forwarded without parsing.
+- **Retries/Timeouts**: none, relies on Serial buffers. The Due generates
+  all `OK:` or `ERR:` responses.
+- **Limitations**: no command validation, no heartbeat, no version check.
+
+## Protocol command summary
+The shared header `firmware/shared/commands.h` defines these tokens:
+
+| Macro | Command | Arguments | Example Response |
+|-------|---------|-----------|-----------------|
+| `CMD_SET_FREQ` | `SF` | `<Hz>` | `OK:SETFREQ` |
+| `CMD_GET_FREQ` | `GF` | – | `OK:FREQ <Hz>` |
+| `CMD_SET_WAVE` | `SW` | `0\|1\|2` | `OK:SETWAVE` |
+| `CMD_GET_WAVE` | `GW` | – | `OK:WAVE <id>` |
+| `CMD_OUTPUT_ON` | `ON` | – | `OK` |
+| `CMD_OUTPUT_OFF` | `OFF` | – | `OK` |
+| `CMD_SAVE` | `SAVE` | `[slot]` | `OK:SAVE` |
+| `CMD_LOAD` | `LOAD` | `[slot]` | `OK:LOAD` |
+| `CMD_DELETE` | `DELETE` | `<slot>` | `OK:DELETE` |
+
+Additional parser-only commands:
+- `STATUS` → `OK:FREQ <Hz> WAVE <id>`
+- `VERSION` → `OK:VERSION <ver>`
+
+## Ambiguities
+- `STATUS` and `VERSION` lack constants in `commands.h`.
+- Output on/off responses are plain `OK` with no token.
+
+## Alignment proposal
+- Keep newline-delimited ASCII with `OK:`/`ERR:` prefixes.
+- Add `CMD_STATUS` and `CMD_VERSION` macros for completeness.
+- Implement a heartbeat and optional version negotiation in later revisions.
+
+## Test coverage
+- Firmware command parsing tested under `tests/firmware/`.
+- CLI interaction tested with stubs in `tests/cli/`.
+- GUI tests run in stub mode due to network limits.
+- No dedicated ESP integration tests yet; planned for v0.4.0.


### PR DESCRIPTION
## Summary
- document ESP and protocol alignment in `docs/spec/esp_protocol_sync.md`
- register the spec folder in `project_structure.md`
- log progress of the coordination work

## Testing
- `make test_all` *(GUI tests fell back to stub mode due to blocked module download)*

------
https://chatgpt.com/codex/tasks/task_e_685369b2c1c0832299a36ed37199c902