### PR TITLE
Add ESP8266 wiring documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation Overview
+
+This folder contains design notes, implementation guides and progress logs for DDS-Controller. Each subfolder focuses on a specific area of the project.
+
+ESP8266-01 support and configuration details are documented under `docs/impl/esp8266.md`.

--- a/docs/impl/esp8266.md
+++ b/docs/impl/esp8266.md
@@ -1,0 +1,69 @@
+# ESP8266-01 Integration
+
+This document describes how the ESP8266-01 WiFi module is wired and configured within DDS-Controller.
+
+## ⚠️ Warning
+
+The ESP8266-01 operates exclusively at **3.3V** logic levels. Applying **5V** to any of its pins will permanently damage the module. Ensure all connections from the Arduino Due use 3.3V or are level shifted appropriately.
+
+## Standard Wiring
+
+The following table shows the default connections for all peripherals when using the LCD Keypad Shield and ESP8266-01 together. All non-shield peripherals are routed to pins **D20** and above to keep the area around the shield clear.
+
+| Arduino Due Pin | Peripheral        | Function            |
+|-----------------|-------------------|--------------------|
+| 8, 9, 4, 5, 6, 7| LCD Keypad Shield | RS,E,D4,D5,D6,D7   |
+| A0              | LCD Keypad Shield | Buttons ADC        |
+| 20              | AD9850 DDS        | WCLK               |
+| 21              | AD9850 DDS        | FQUD               |
+| 22              | AD9850 DDS        | DATA               |
+| 23              | AD9850 DDS        | RESET              |
+| 25              | DDS Output Enable | Control line       |
+| 52              | ESP8266-01        | RX (to Due TX)     |
+| 53              | ESP8266-01        | TX (to Due RX)     |
+| 24              | ESP8266-01        | GPIO2 / status LED |
+
+### Alternative Pins
+
+If the default layout does not fit your build, any of the above connections may be reassigned through the configuration headers described below. Keep in mind the policy of using pins **>= D20** for all peripherals except the LCD shield.
+
+```
+D20..D53  -> custom peripherals
+< D20     -> reserved for shield and internal functions
+```
+
+## Custom Configuration
+
+All pin assignments are defined in `firmware/shared/config/pins.h`. This header uses simple `#define` statements:
+
+```cpp
+#define PIN_ESP_RX     52
+#define PIN_ESP_TX     53
+#define PIN_ESP_LED    24
+```
+
+Edit these values to match your wiring. Peripherals can be effectively disabled by setting their pin number to `-1` and guarding the usage in code. No YAML or JSON configuration is required—only these header files.
+
+## OTA Update Mode
+
+Over‑the‑air updates for the ESP8266-01 rely on its **GPIO0** pin. When OTA mode is enabled, GPIO0 must be reserved for the bootloader and should not be used for other circuitry. With OTA disabled, both GPIO0 and GPIO2 are free for user functions.
+
+Example configuration in `pins.h`:
+
+```cpp
+// OTA enabled – GPIO0 reserved
+#define PIN_ESP_GPIO0  0  // Do not connect to other hardware
+#define PIN_ESP_GPIO2  24 // status LED
+
+// OTA disabled – both pins available
+//#define PIN_ESP_GPIO0  26 // example user pin
+//#define PIN_ESP_GPIO2  24
+```
+
+Ensure the `ota_mode` setting in your ESP firmware matches this wiring.
+
+## See Also
+
+- `docs/hardware/pinmap.md` – authoritative wiring table
+- `docs/guides/ota_esp8266.md` – step‑by‑step OTA procedure
+

--- a/docs/impl/main.md
+++ b/docs/impl/main.md
@@ -7,3 +7,6 @@ During `setup()` it creates `LiquidCrystal`, `ButtonManager`, `EEPROMManager`, `
 The `loop()` function updates the menu system and checks the two serial ports for incoming commands. Each command is parsed by `CommandParser` and the response is sent back on the originating interface, enabling transparent USB or WiFi operation.
 
 Output on/off actions are handled via `MenuSystem` by toggling `OUTPUT_CONTROL_PIN`.
+
+For details on connecting and configuring the WiFi module see
+[`esp8266.md`](esp8266.md).


### PR DESCRIPTION
## Summary
- document ESP8266-01 integration and OTA options
- link the new guide from `docs/impl/main.md`
- add docs/README with mention of WiFi module

## Testing
- `make test_all`

------
https://chatgpt.com/codex/tasks/task_e_6853754673d88322a1a0d65a0cb6531f