### PR TITLE
Add ESP8266 OTA and command integration

### DIFF
--- a/docs/hardware/pinmap.md
+++ b/docs/hardware/pinmap.md
@@ -6,13 +6,13 @@
 |-----------------|-------------------|----------------|------------------------------------|
 | 8, 9, 4, 5, 6, 7| LCD Keypad Shield | RS,E,D4,D5,D6,D7 | Uses standard Arduino shield layout |
 | A0              | LCD Keypad Shield | Buttons ADC    | Reads multiple buttons via resistor ladder |
-| 20              | AD9850 DDS        | WCLK           | Serial clock to DDS module         |
-| 21              | AD9850 DDS        | FQUD           | Frequency update                   |
-| 22              | AD9850 DDS        | DATA           | Serial data                        |
-| 23              | AD9850 DDS        | RESET          | Module reset                       |
+| 10              | AD9850 DDS        | WCLK           | Serial clock to DDS module         |
+| 11              | AD9850 DDS        | FQUD           | Frequency update                   |
+| 12              | AD9850 DDS        | DATA           | Serial data                        |
+| 13              | AD9850 DDS        | RESET          | Module reset                       |
 | 24              | ESP8266-01        | GPIO2          | WiFi status LED                    |
-| 52              | ESP8266-01        | RX             | Connected to Due TX (SoftwareSerial) |
-| 53              | ESP8266-01        | TX             | Connected to Due RX (SoftwareSerial) |
+| 20              | ESP8266-01        | RX             | Connected to Due TX (SoftwareSerial) |
+| 21              | ESP8266-01        | TX             | Connected to Due RX (SoftwareSerial) |
 | 25              | DDS Output Enable | Control line   | Toggles DDS output                 |
 
 **Safety Notice:** The ESP8266-01 module operates at **3.3V** logic levels only. Connecting it directly to 5V will permanently damage the module.

--- a/firmware/due/CommandParser.cpp
+++ b/firmware/due/CommandParser.cpp
@@ -2,6 +2,10 @@
 #include <cstdlib>
 #include <cstring>
 #include "../shared/commands.h"
+#include "../shared/config/config.h"
+#ifdef USE_ESP
+#include "esp_protocol.h"
+#endif
 
 void CommandParser::begin(DDSDriver& d, EEPROMManager& e) {
     dds = &d;
@@ -58,6 +62,36 @@ String CommandParser::handleCommand(const String& cmd) {
         eeprom->deletePreset(id);
         return "OK:DELETE";
     }
+#ifdef USE_ESP
+    if (cmd == CMD_ESP_ON) {
+        esp_send(CMD_ESP_ON);
+        return "OK:ESPON";
+    }
+    if (cmd == CMD_ESP_OFF) {
+        esp_send(CMD_ESP_OFF);
+        return "OK:ESPOFF";
+    }
+    if (cmd == CMD_ESP_STATUS) {
+        esp_send(CMD_ESP_STATUS);
+        return "OK:REQ";
+    }
+    if (cmd.rfind(CMD_ESP_MODE, 0) == 0) {
+        esp_send(cmd);
+        return "OK:MODE";
+    }
+    if (cmd == CMD_ESP_LED_ON) {
+        digitalWrite(PIN_ESP_LED, HIGH);
+        return "OK:LEDON";
+    }
+    if (cmd == CMD_ESP_LED_OFF) {
+        digitalWrite(PIN_ESP_LED, LOW);
+        return "OK:LEDOFF";
+    }
+#else
+    if (cmd.rfind("ESP", 0) == 0) {
+        return "ERR:ESP_DISABLED";
+    }
+#endif
     if (cmd == "STATUS") {
         return String("OK:FREQ ") + std::to_string(dds->getFrequency()) +
                " WAVE " + std::to_string(dds->getWaveform());

--- a/firmware/due/DDSDriver.cpp
+++ b/firmware/due/DDSDriver.cpp
@@ -3,12 +3,13 @@
 #ifdef ARDUINO
 #include <Arduino.h>
 #endif
+#include "../shared/config/pins.h"
 
-// Default pin mapping for AD9850 module
-static constexpr int PIN_WCLK  = 10;
-static constexpr int PIN_FQUD  = 11;
-static constexpr int PIN_DATA  = 12;
-static constexpr int PIN_RESET = 13;
+// Pin mapping for AD9850 module comes from config
+static constexpr int PIN_WCLK  = PIN_DDS_WCLK;
+static constexpr int PIN_FQUD  = PIN_DDS_FQUD;
+static constexpr int PIN_DATA  = PIN_DDS_DATA;
+static constexpr int PIN_RESET = PIN_DDS_RESET;
 
 void DDSDriver::begin() {
 #ifdef ARDUINO

--- a/firmware/due/MenuSystem.cpp
+++ b/firmware/due/MenuSystem.cpp
@@ -1,4 +1,9 @@
 #include "MenuSystem.h"
+#include "../shared/config/config.h"
+#include "../shared/commands.h"
+#ifdef USE_ESP
+#include "esp_protocol.h"
+#endif
 
 // ---------------------------------------------------------------------------
 // Local state
@@ -49,7 +54,7 @@ const Item MENU[] = {
         {ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU}, 0, false},
     // SYSTEM_MENU
     {ID::SYSTEM_MENU, "Rendszer", ID::MAIN_MENU,
-        {ID::SHOW_VERSION, ID::RESET_DEFAULTS, ID::PRESET_MENU, ID::EXIT_MENU}, 4, false},
+        {ID::SHOW_VERSION, ID::RESET_DEFAULTS, ID::PRESET_MENU, ID::ESP_MENU}, 4, false},
     // SHOW_VERSION
     {ID::SHOW_VERSION, "Firmware", ID::SYSTEM_MENU,
         {ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU}, 0, false},
@@ -68,6 +73,18 @@ const Item MENU[] = {
     // PRESET_DELETE
     {ID::PRESET_DELETE, "T\xF6rl\xE9s Preset", ID::PRESET_MENU,
         {ID::PRESET_MENU, ID::PRESET_MENU, ID::PRESET_MENU, ID::PRESET_MENU}, 0, true},
+    // ESP_MENU
+    {ID::ESP_MENU, "WiFi", ID::SYSTEM_MENU,
+        {ID::ESP_ON, ID::ESP_OFF, ID::ESP_STATUS, ID::SYSTEM_MENU}, 3, false},
+    // ESP_ON
+    {ID::ESP_ON, "ESP bekapcs", ID::ESP_MENU,
+        {ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU}, 0, false},
+    // ESP_OFF
+    {ID::ESP_OFF, "ESP kikapcs", ID::ESP_MENU,
+        {ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU}, 0, false},
+    // ESP_STATUS
+    {ID::ESP_STATUS, "ESP info", ID::ESP_MENU,
+        {ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU, ID::SYSTEM_MENU}, 0, false},
     // EXIT_MENU
     {ID::EXIT_MENU, "Kil\xE9p\xE9s", ID::SYSTEM_MENU,
         {ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU, ID::MAIN_MENU}, 0, false},
@@ -249,6 +266,17 @@ void MenuSystem::applyAction(MenuID action) {
   case OUTPUT_OFF:
     digitalWrite(OUTPUT_CONTROL_PIN, LOW);
     break;
+#ifdef USE_ESP
+  case ESP_ON:
+    esp_send(CMD_ESP_ON);
+    break;
+  case ESP_OFF:
+    esp_send(CMD_ESP_OFF);
+    break;
+  case ESP_STATUS:
+    esp_send(CMD_ESP_STATUS);
+    break;
+#endif
   case RESET_DEFAULTS:
     freq = 1000000;
     dds.setFrequency(freq);

--- a/firmware/due/MenuSystem.h
+++ b/firmware/due/MenuSystem.h
@@ -13,8 +13,10 @@
 #include "EEPROMManager.h"
 #include "DDSDriver.h"
 
+#include "../shared/config/pins.h"
+
 // Digital pin used to enable or disable the DDS output
-#define OUTPUT_CONTROL_PIN 2
+#define OUTPUT_CONTROL_PIN PIN_OUTPUT_CONTROL
 
 class MenuSystem {
 public:
@@ -41,7 +43,11 @@ public:
         PRESET_SAVE,
         PRESET_LOAD,
         PRESET_DELETE,
-        EXIT_MENU
+        EXIT_MENU,
+        ESP_MENU,
+        ESP_ON,
+        ESP_OFF,
+        ESP_STATUS
     };
 
     struct MenuItem {

--- a/firmware/due/esp_protocol.cpp
+++ b/firmware/due/esp_protocol.cpp
@@ -1,0 +1,27 @@
+#include "esp_protocol.h"
+#include "CommandParser.h"
+
+#ifdef USE_ESP
+static SerialPort* espPort = nullptr;
+static CommandParser* cmdParser = nullptr;
+
+void esp_begin(SerialPort& serial, CommandParser& parser) {
+    espPort = &serial;
+    cmdParser = &parser;
+}
+
+void esp_send(const String& cmd) {
+    if (espPort) {
+        espPort->println(cmd);
+    }
+}
+
+void esp_handle() {
+    if (!espPort || !cmdParser) return;
+    if (espPort->available()) {
+        String c = espPort->readStringUntil('\n');
+        String resp = cmdParser->handleCommand(c);
+        espPort->println(resp);
+    }
+}
+#endif // USE_ESP

--- a/firmware/due/esp_protocol.h
+++ b/firmware/due/esp_protocol.h
@@ -1,0 +1,26 @@
+#ifndef ESP_PROTOCOL_H
+#define ESP_PROTOCOL_H
+
+#include "../shared/config/config.h"
+
+#ifdef USE_ESP
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <SoftwareSerial.h>
+using SerialPort = SoftwareSerial;
+#else
+#include "mocks/Arduino.h"
+#include "mocks/SoftwareSerial.h"
+using SerialPort = SoftwareSerialMock;
+#endif
+
+class CommandParser;
+
+void esp_begin(SerialPort& serial, CommandParser& parser);
+void esp_handle();
+void esp_send(const String& cmd);
+
+#endif // USE_ESP
+
+#endif // ESP_PROTOCOL_H

--- a/firmware/due/mocks/SoftwareSerial.h
+++ b/firmware/due/mocks/SoftwareSerial.h
@@ -1,0 +1,34 @@
+#ifndef SOFTWARESERIAL_MOCK_H
+#define SOFTWARESERIAL_MOCK_H
+
+#include <string>
+#include <iostream>
+
+class SoftwareSerialMock {
+public:
+    SoftwareSerialMock(int rx, int tx) {}
+    void begin(long) {}
+    bool available() { return !buffer.empty(); }
+    char read() {
+        if (buffer.empty()) return 0;
+        char c = buffer.front();
+        buffer.erase(buffer.begin());
+        return c;
+    }
+    std::string readStringUntil(char term) {
+        std::string out;
+        while (!buffer.empty()) {
+            char c = read();
+            if (c == term) break;
+            out += c;
+        }
+        return out;
+    }
+    void inject(const std::string& s) { buffer += s; }
+    void print(const std::string& s) { std::cout << s; }
+    void println(const std::string& s) { std::cout << s << std::endl; }
+private:
+    std::string buffer;
+};
+
+#endif // SOFTWARESERIAL_MOCK_H

--- a/firmware/shared/commands.h
+++ b/firmware/shared/commands.h
@@ -19,4 +19,12 @@
 #define CMD_LOAD   "LOAD"   // Load from EEPROM or preset slot
 #define CMD_DELETE "DELETE" // Delete preset slot
 
+// ESP8266 control commands
+#define CMD_ESP_ON      "ESPON"
+#define CMD_ESP_OFF     "ESPOFF"
+#define CMD_ESP_STATUS  "ESPSTS"
+#define CMD_ESP_MODE    "ESPMODE"
+#define CMD_ESP_LED_ON  "ESPLEDON"
+#define CMD_ESP_LED_OFF "ESPLEDOFF"
+
 #endif // SHARED_COMMANDS_H

--- a/firmware/shared/config/config.h
+++ b/firmware/shared/config/config.h
@@ -1,0 +1,21 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "pins.h"
+
+// Set to 1 to enable ESP8266 support
+#ifndef USE_ESP
+#define USE_ESP 1
+#endif
+
+// Set to 1 to enable OTA mode. If disabled, Arduino can pull GPIO0 low for flashing
+#ifndef USE_ESP_OTA
+#define USE_ESP_OTA 1
+#endif
+
+#define ESP_BAUD_RATE 9600
+
+// Optional pin for controlling ESP8266 GPIO0 when OTA is disabled
+#define PIN_ESP_GPIO0 26
+
+#endif // CONFIG_H

--- a/firmware/shared/config/pins.h
+++ b/firmware/shared/config/pins.h
@@ -5,17 +5,18 @@
 // Adjust these values to match the wiring as documented in docs/hardware/pinmap.md
 
 // DDS (AD9850)
-#define PIN_DDS_WCLK   20
-#define PIN_DDS_FQUD   21
-#define PIN_DDS_DATA   22
-#define PIN_DDS_RESET  23
+#define PIN_DDS_WCLK   10
+#define PIN_DDS_FQUD   11
+#define PIN_DDS_DATA   12
+#define PIN_DDS_RESET  13
 
 // ESP8266-01 communication via SoftwareSerial
-#define PIN_ESP_RX     52  // Due TX to ESP8266 RX
-#define PIN_ESP_TX     53  // Due RX to ESP8266 TX
+#define PIN_ESP_RX     20  // Due TX to ESP8266 RX
+#define PIN_ESP_TX     21  // Due RX to ESP8266 TX
 #define PIN_ESP_LED    24  // GPIO2 on ESP8266
 
 // Control output
-#define OUTPUT_CONTROL_PIN 25
+#define PIN_OUTPUT_CONTROL 25
+#define OUTPUT_CONTROL_PIN PIN_OUTPUT_CONTROL
 
 #endif // CONFIG_PINS_H


### PR DESCRIPTION
## Summary
- support ESP8266-01 via new config options
- route WiFi commands through new `esp_protocol` module
- extend `CommandParser` to handle ESP commands
- expose WiFi control in menu system
- centralize pin mappings and update hardware docs

## Testing
- `make test_all`

------
https://chatgpt.com/codex/tasks/task_e_685376656ccc8322af321bc0bb734cf2