### PR TITLE
Start ESP8266-01 integration

### DIFF
--- a/docs/hardware/esp8266.md
+++ b/docs/hardware/esp8266.md
@@ -1,0 +1,18 @@
+# ESP8266-01 Wiring Notes
+
+The ESP8266-01 module is integrated as a WiFi bridge for the DDS-Controller. It must be powered by **3.3V** only. Refer to the table in `pinmap.md` for default Arduino Due connections.
+
+```
+          +-----------+
+  TX_PIN -| TX     VCC|- 3.3V supply
+  RX_PIN -| RX     CH_PD|- pulled high (10k)
+ GPIO0_LED-| GPIO0  RST|- reset (to Due or RC)
+ GPIO2_CMD-| GPIO2  GND|- GND
+          +-----------+
+```
+
+- **GPIO2_CMD** (GPIO2) is wired to an available Due pin (default 24). It allows the ESP to signal or send commands.
+- **GPIO0_LED** (GPIO0) controls a WiFi status LED whenever OTA updates are enabled. Otherwise this pin remains un-driven so the Arduino Due can repurpose it.
+- UART pins start from Due pin **20** upward to avoid conflicts with the LCD shield.
+
+Use level shifting if any connection might expose the ESP8266-01 to 5V. See the in-code comments in `firmware/esp/main.cpp` for further notes.

--- a/docs/hardware/pinmap.md
+++ b/docs/hardware/pinmap.md
@@ -11,8 +11,11 @@
 | 12              | AD9850 DDS        | DATA           | Serial data                        |
 | 13              | AD9850 DDS        | RESET          | Module reset                       |
 | 24              | ESP8266-01        | GPIO2          | WiFi status LED                    |
+| 26              | ESP8266-01        | GPIO0          | OTA LED or Arduino control |
 | 20              | ESP8266-01        | RX             | Connected to Due TX (SoftwareSerial) |
 | 21              | ESP8266-01        | TX             | Connected to Due RX (SoftwareSerial) |
 | 25              | DDS Output Enable | Control line   | Toggles DDS output                 |
 
 **Safety Notice:** The ESP8266-01 module operates at **3.3V** logic levels only. Connecting it directly to 5V will permanently damage the module.
+
+Connections for optional modules start from pin 20 upwards to avoid conflicts with the LCD shield.

--- a/docs/progress/2025-06-19_03-22-02_esp_agent_v0.4.0_kickoff.md
+++ b/docs/progress/2025-06-19_03-22-02_esp_agent_v0.4.0_kickoff.md
@@ -1,0 +1,6 @@
+# ESP Agent Kickoff Log – 2025-06-19 03:22:26 CEST
+
+- Added initial ESP8266-01 configuration parser (`firmware/esp/esp_config.cpp`).
+- Created `firmware/esp/main.cpp` implementing basic OTA-aware GPIO handling and serial bridge.
+- Provided sample INI file `firmware/shared/config_esp.ini` for runtime settings.
+- Documented wiring details in `docs/hardware/esp8266.md`.

--- a/firmware/esp/esp_config.cpp
+++ b/firmware/esp/esp_config.cpp
@@ -1,0 +1,37 @@
+#include "esp_config.h"
+
+bool loadEspConfig(const char* path, EspConfig& cfg) {
+  if (!SPIFFS.begin()) {
+    return false;
+  }
+  File f = SPIFFS.open(path, "r");
+  if (!f) {
+    return false;
+  }
+  bool inSection = false;
+  while (f.available()) {
+    String line = f.readStringUntil('\n');
+    line.trim();
+    if (line.length() == 0 || line.startsWith("#")) continue;
+    if (line.startsWith("[") && line.endsWith("]")) {
+      inSection = line.equalsIgnoreCase("[ESP]");
+      continue;
+    }
+    if (!inSection) continue;
+    int eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    String key = line.substring(0, eq); key.trim();
+    String val = line.substring(eq + 1); val.trim();
+    if (key.equalsIgnoreCase("ENABLE_OTA")) {
+      cfg.enable_ota = (val == "true" || val == "1");
+    } else if (key.equalsIgnoreCase("GPIO0_LED")) {
+      cfg.gpio0_led = (val == "true" || val == "1");
+    } else if (key.equalsIgnoreCase("TX_PIN")) {
+      cfg.tx_pin = val.toInt();
+    } else if (key.equalsIgnoreCase("RX_PIN")) {
+      cfg.rx_pin = val.toInt();
+    }
+  }
+  f.close();
+  return true;
+}

--- a/firmware/esp/esp_config.h
+++ b/firmware/esp/esp_config.h
@@ -1,0 +1,16 @@
+#ifndef ESP_CONFIG_H
+#define ESP_CONFIG_H
+
+#include <Arduino.h>
+#include <FS.h>
+
+struct EspConfig {
+  bool enable_ota = true;
+  bool gpio0_led = true;
+  int tx_pin = 2;
+  int rx_pin = 3;
+};
+
+bool loadEspConfig(const char* path, EspConfig& cfg);
+
+#endif // ESP_CONFIG_H

--- a/firmware/esp/main.cpp
+++ b/firmware/esp/main.cpp
@@ -1,0 +1,44 @@
+#include <ESP8266WiFi.h>
+#include <SoftwareSerial.h>
+#include <ArduinoOTA.h>
+#include "../shared/config/config.h"
+#include "esp_config.h"
+
+// See docs/hardware/esp8266.md for wiring and voltage notes.
+
+static EspConfig cfg;
+static SoftwareSerial dueSerial(cfg.rx_pin, cfg.tx_pin);
+
+void setup() {
+  Serial.begin(115200);
+  SPIFFS.begin();
+  loadEspConfig("/config_esp.ini", cfg);
+
+  dueSerial.begin(ESP_BAUD_RATE);
+  pinMode(PIN_ESP_LED, OUTPUT);
+  pinMode(PIN_OUTPUT_CONTROL, OUTPUT);
+
+  // GPIO0 controls WiFi status LED when OTA enabled
+  if (cfg.enable_ota) {
+    pinMode(PIN_ESP_GPIO0, OUTPUT);
+    digitalWrite(PIN_ESP_GPIO0, LOW);
+    ArduinoOTA.begin();
+  } else {
+    pinMode(PIN_ESP_GPIO0, INPUT); // allow Arduino to drive if needed
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin("DDS", "password");
+}
+
+void loop() {
+  if (cfg.enable_ota) {
+    ArduinoOTA.handle();
+  }
+  if (Serial.available()) {
+    dueSerial.write(Serial.read());
+  }
+  if (dueSerial.available()) {
+    Serial.write(dueSerial.read());
+  }
+}

--- a/firmware/shared/config_esp.ini
+++ b/firmware/shared/config_esp.ini
@@ -1,0 +1,5 @@
+[ESP]
+ENABLE_OTA=true
+GPIO0_LED=true
+TX_PIN=2
+RX_PIN=3


### PR DESCRIPTION
## Summary
- begin ESP8266 integration for milestone v0.4.0
- document wiring and pin requirements for the ESP8266-01
- add config parser for ESP settings and sample INI file
- create OTA-aware ESP firmware entry point
- log kickoff progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685381d6b9c4832295a536926e2279e5