### PR TITLE
Add v0.4.0 timeline sync

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -8,10 +8,10 @@
 - [DISPATCHED] ESP protocol implementation ([log](docs/progress/2025-06-18_16-31-18_root_agent_dispatch_esp_protocol.md))
 - [x] ~~Web UI~~ *(canceled)* ([note](docs/progress/2025-06-18_10-33_placeholder_audit.md))
 - [x] EEPROM preset handling ([log](docs/progress/2025-06-18_07-42-12_firmware_agent_presets.md))
-- [PLANNED] Milestone v0.4.0 kickoff – expand remote control, web UI and testing
+- [IN_PROGRESS] Milestone v0.4.0 kickoff – expand remote control, web UI and testing
 - [IN_PROGRESS] ESP+UI hardware coordination ([log](docs/progress/2025-06-19_root_audit_esp_ui.md))
 
-## v0.4.0 – Remote Control Expansion (PLANNED)
+## v0.4.0 – Remote Control Expansion (IN_PROGRESS)
 - Kickoff: 2025-06-18
   - Goals:
     - Implement ESP8266 WiFi bridge with heartbeat

--- a/TODO.md
+++ b/TODO.md
@@ -38,3 +38,5 @@
 - [DONE] (root_agent) Final ESP+UI integration audit (see docs/progress/2025-06-19_root_audit_esp_ui.md)
 - [DONE] (timeline_agent) Milestone v0.4.0 summary dispatched (docs/reports/milestone_v0.4.0_summary.md)
 - [DONE] (pc_agent) OTA and config CLI/GUI support (see docs/progress/2025-06-19_09-00-00_pc_agent_ota_config.md)
+- [TODO] (timeline_agent) Create docs/versions/v0.4.0.md recording milestone kickoff details
+- [TODO] (esp_agent, protocol_agent, pc_agent, ui_agent) Provide progress logs for coordination prompts issued 2025-06-18 17:52

--- a/docs/progress/2025-06-18_timeline_sync_v0.4.0.md
+++ b/docs/progress/2025-06-18_timeline_sync_v0.4.0.md
@@ -1,0 +1,32 @@
+# Timeline Agent Log – v0.4.0 Prompt Sync
+Date: 2025-06-18 18:15 CEST
+
+Checked milestone v0.4.0 prompt dispatches and coordination tasks. Logs are listed below.
+
+## Prompt Status
+| Agent | Prompt File | Progress Log |
+|-------|-------------|--------------|
+| docs_agent | docs/prompts/docs_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_04-55-19_docs_agent_configuration.md |
+| esp_agent | docs/prompts/esp_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_03-22-02_esp_agent_v0.4.0_kickoff.md |
+| firmware_agent | docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md | ❌ |
+| pc_agent | docs/prompts/pc_agent/2025-06-18_17-43-41_v0.4.0_plan.md | ❌ |
+| pc_agent | docs/prompts/pc_agent/2025-06-18_v0.4.0_ota_and_config.md | docs/progress/2025-06-19_09-00-00_pc_agent_ota_config.md |
+| protocol_agent | docs/prompts/protocol_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-18_20-45_protocol_agent_esp_commands.md |
+| test_coverage_agent | docs/prompts/test_coverage_agent/2025-06-18_17-43-41_v0.4.0_plan.md | ❌ |
+| timeline_agent | docs/prompts/timeline_agent/2025-06-18_17-43-41_v0.4.0_plan.md | ❌ |
+| ui_agent | docs/prompts/ui_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_04-55-19_ui_agent_web_ui.md |
+
+## Coordination Tasks
+| Agent Pair | Prompt File | Progress Log |
+|------------|-------------|--------------|
+| esp_agent ↔ protocol_agent | docs/prompts/esp_agent/2025-06-18_17-52_coord_protocol_agent.md | ❌ |
+| protocol_agent ↔ esp_agent | docs/prompts/protocol_agent/2025-06-18_17-52_coord_esp_agent.md | ❌ |
+| ui_agent ↔ pc_agent | docs/prompts/ui_agent/2025-06-18_17-52_coord_pc_agent.md | ❌ |
+| pc_agent ↔ ui_agent | docs/prompts/pc_agent/2025-06-18_17-52_coord_ui_agent.md | ❌ |
+
+## Status Counts
+- Total prompts parsed: 13
+- Logs found: 5
+- Missing logs: 8
+
+Missing version file `docs/versions/v0.4.0.md`.


### PR DESCRIPTION
## Summary
- log v0.4.0 prompt dispatch review in `docs/progress/`
- mark milestone kickoff as in-progress
- note missing version file and coordination logs in TODO

## Testing
- `make test_all` *(fails: gui tests need network access)*

------
https://chatgpt.com/codex/tasks/task_e_68538a535a048322a0f26611c77f07a9