### PR TITLE
Add v0.4.0 audit log

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,3 +40,5 @@
 - [DONE] (pc_agent) OTA and config CLI/GUI support (see docs/progress/2025-06-19_09-00-00_pc_agent_ota_config.md)
 - [TODO] (timeline_agent) Create docs/versions/v0.4.0.md recording milestone kickoff details
 - [TODO] (esp_agent, protocol_agent, pc_agent, ui_agent) Provide progress logs for coordination prompts issued 2025-06-18 17:52
+- [TODO] (docs_agent) Finalize CHANGELOG.md for v0.4.0 and log completion
+- [TODO] (firmware_agent) Provide progress log for ESP bridge integration prompt (2025-06-18_17-43-41_v0.4.0_plan.md)

--- a/docs/progress/2025-06-18_21-15-00_root_agent_v0.4.0_audit.md
+++ b/docs/progress/2025-06-18_21-15-00_root_agent_v0.4.0_audit.md
@@ -1,0 +1,29 @@
+# Root Agent v0.4.0 Progress Audit – 2025-06-18 21:15 CEST
+
+Reviewed milestone status, TODO entries, and progress logs for all agents involved in milestone **v0.4.0**. Documentation and configuration files were also checked for consistency.
+
+## Summary Table
+| Agent | Plan Prompt | Progress Log | Issues |
+|-------|-------------|--------------|-------|
+| esp_agent | docs/prompts/esp_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_03-22-02_esp_agent_v0.4.0_kickoff.md | Missing coordination log with protocol_agent |
+| protocol_agent | docs/prompts/protocol_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-18_20-45_protocol_agent_esp_commands.md | Missing coordination log |
+| firmware_agent | docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md | *none* | No progress log recorded |
+| ui_agent | docs/prompts/ui_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_04-55-19_ui_agent_web_ui.md | Coordination log with pc_agent missing |
+| docs_agent | docs/prompts/docs_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_04-55-19_docs_agent_configuration.md | CHANGELOG.md not created |
+| test_coverage_agent | docs/prompts/test_coverage_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_05-54-03_test_coverage_update.md | - |
+| pc_agent | docs/prompts/pc_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-19_09-00-00_pc_agent_ota_config.md | Coordination log missing |
+| timeline_agent | docs/prompts/timeline_agent/2025-06-18_17-43-41_v0.4.0_plan.md | docs/progress/2025-06-18_timeline_sync_v0.4.0.md | `docs/versions/v0.4.0.md` pending |
+
+## Documentation Check
+- Pin and OTA references exist under `docs/configuration/` and `docs/impl/`.
+- Hardware connection map present (`docs/impl/hardware_connection_map.md`).
+- Firmware pin header validates unique assignments (`firmware/shared/config/pins.h`).
+- Web UI added under `firmware/esp/web_ui/`.
+
+## Outstanding Items
+- `CHANGELOG.md` missing.
+- `docs/versions/v0.4.0.md` not yet created.
+- Firmware agent has not logged progress for the ESP bridge integration.
+- Coordination logs for ESP↔Protocol and UI↔PC agents not found.
+
+Follow-up TODO items have been added for documentation and firmware logs.


### PR DESCRIPTION
## Summary
- add root agent v0.4.0 audit log with missing progress notes
- add TODO follow ups for firmware and documentation

## Testing
- `make test_all` *(fails to fetch Go modules; stub GUI tests succeed)*

------
https://chatgpt.com/codex/tasks/task_e_68538bc841b88322bea275dab718b3b8