### PR TITLE
Finalize v0.4.0 kickoff dispatches

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@
 - [DONE] (root_agent) Final ESP+UI integration audit (see docs/progress/2025-06-19_root_audit_esp_ui.md)
 - [DONE] (timeline_agent) Milestone v0.4.0 summary dispatched (docs/reports/milestone_v0.4.0_summary.md)
 - [DONE] (pc_agent) OTA and config CLI/GUI support (see docs/progress/2025-06-19_09-00-00_pc_agent_ota_config.md)
-- [TODO] (timeline_agent) Create docs/versions/v0.4.0.md recording milestone kickoff details
-- [TODO] (esp_agent, protocol_agent, pc_agent, ui_agent) Provide progress logs for coordination prompts issued 2025-06-18 17:52
-- [TODO] (docs_agent) Finalize CHANGELOG.md for v0.4.0 and log completion
-- [TODO] (firmware_agent) Provide progress log for ESP bridge integration prompt (2025-06-18_17-43-41_v0.4.0_plan.md)
+- [DISPATCHED] (timeline_agent) Create docs/versions/v0.4.0.md recording milestone kickoff details
+- [DISPATCHED] (esp_agent, protocol_agent, pc_agent, ui_agent) Provide progress logs for coordination prompts issued 2025-06-18 17:52
+- [DISPATCHED] (docs_agent) Finalize CHANGELOG.md for v0.4.0 and log completion
+- [DISPATCHED] (firmware_agent) Provide progress log for ESP bridge integration prompt (2025-06-18_17-43-41_v0.4.0_plan.md)

--- a/docs/progress/2025-06-19_root_agent_v0.4.0_finalization.md
+++ b/docs/progress/2025-06-19_root_agent_v0.4.0_finalization.md
@@ -1,0 +1,12 @@
+# Milestone v0.4.0 Finalization – 2025-06-19 10:45 CEST
+
+Issued follow-up prompts to resolve outstanding kickoff tasks.
+
+## Dispatches
+- docs_agent – finalize CHANGELOG and log completion
+- timeline_agent – create docs/versions/v0.4.0.md
+- firmware_agent – provide ESP bridge progress log
+- esp_agent & protocol_agent – document serial format and heartbeat
+- ui_agent & pc_agent – log UI alignment results
+
+All tasks were marked as DISPATCHED in `TODO.md` and prompt files placed under `docs/prompts/*/2025-06-19_10-45_*.md`.

--- a/docs/prompts/docs_agent/2025-06-19_10-45_finalize_changelog.md
+++ b/docs/prompts/docs_agent/2025-06-19_10-45_finalize_changelog.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: docs_agent
+Task: Finalize CHANGELOG for v0.4.0
+Target File(s): CHANGELOG.md
+Related Docs: docs/progress/2025-06-18_17-43-41_root_agent_v0.4.0_dispatch.md
+
+### Prompt Body
+Complete `CHANGELOG.md` summarizing notable updates for version v0.4.0. Reference relevant progress logs and place the file at the repository root. Log your work to `docs/progress/2025-06-19_10-45_docs_agent_changelog.md`.

--- a/docs/prompts/esp_agent/2025-06-19_10-45_log_coordination.md
+++ b/docs/prompts/esp_agent/2025-06-19_10-45_log_coordination.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: esp_agent
+Task: Log protocol coordination
+Target File(s): docs/progress/2025-06-18_17-52_esp_agent_protocol_coord.md
+Related Docs: docs/prompts/esp_agent/2025-06-18_17-52_coord_protocol_agent.md
+
+### Prompt Body
+Record the final serial message format and heartbeat timing agreed with `protocol_agent`. Update `docs/design/protocol_layers.md` if changes were made. Log your summary in the referenced progress file.

--- a/docs/prompts/firmware_agent/2025-06-19_10-45_progress_log_esp_bridge.md
+++ b/docs/prompts/firmware_agent/2025-06-19_10-45_progress_log_esp_bridge.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: firmware_agent
+Task: Provide progress log for ESP bridge integration
+Target File(s): docs/progress/2025-06-18_17-43-41_firmware_agent_v0.4.0.md
+Related Docs: docs/prompts/firmware_agent/2025-06-18_17-43-41_v0.4.0_plan.md
+
+### Prompt Body
+Summarize the current state of ESP bridge integration as requested in the 2025-06-18 plan. Note command routing and non-blocking loop updates. Record everything in the referenced progress log file.

--- a/docs/prompts/pc_agent/2025-06-19_10-45_log_alignment.md
+++ b/docs/prompts/pc_agent/2025-06-19_10-45_log_alignment.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: pc_agent
+Task: Log alignment with ui_agent
+Target File(s): docs/progress/2025-06-18_17-52_pc_ui_coord.md
+Related Docs: docs/prompts/pc_agent/2025-06-18_17-52_coord_ui_agent.md
+
+### Prompt Body
+Provide a summary of the Qt GUI adjustments after coordinating with `ui_agent`. Mention any updated controls or endpoints and save the details in the referenced progress log file.

--- a/docs/prompts/protocol_agent/2025-06-19_10-45_log_coordination.md
+++ b/docs/prompts/protocol_agent/2025-06-19_10-45_log_coordination.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: protocol_agent
+Task: Log ESP coordination
+Target File(s): docs/progress/2025-06-18_17-52_protocol_agent_esp_coord.md
+Related Docs: docs/prompts/protocol_agent/2025-06-18_17-52_coord_esp_agent.md
+
+### Prompt Body
+Document your view of the agreed UART packet structure and heartbeat timing after working with `esp_agent`. Update `docs/design/protocol_layers.md` as necessary and fill in the referenced progress log.

--- a/docs/prompts/timeline_agent/2025-06-19_10-45_create_version.md
+++ b/docs/prompts/timeline_agent/2025-06-19_10-45_create_version.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: timeline_agent
+Task: Document milestone kickoff
+Target File(s): docs/versions/v0.4.0.md
+Related Docs: docs/progress/2025-06-18_17-43-41_root_agent_v0.4.0_dispatch.md
+
+### Prompt Body
+Create `docs/versions/v0.4.0.md` capturing milestone kickoff details referencing the root agent dispatch log. Update the TODO registry status and log your work to `docs/progress/2025-06-19_10-45_timeline_agent_version_log.md`.

--- a/docs/prompts/ui_agent/2025-06-19_10-45_log_alignment.md
+++ b/docs/prompts/ui_agent/2025-06-19_10-45_log_alignment.md
@@ -1,0 +1,8 @@
+### Prompt Metadata
+Agent: ui_agent
+Task: Log alignment with pc_agent
+Target File(s): docs/progress/2025-06-18_17-52_ui_pc_coord.md
+Related Docs: docs/prompts/ui_agent/2025-06-18_17-52_coord_pc_agent.md
+
+### Prompt Body
+Summarize your coordination results with `pc_agent`. Note REST endpoint or label updates ensuring parity between Web UI and Qt GUI. Write the summary to the referenced progress log file.


### PR DESCRIPTION
## Summary
- dispatch follow-ups for missing v0.4.0 kickoff logs
- mark outstanding tasks as dispatched
- record root agent finalization log

## Testing
- `make test_all`

------
https://chatgpt.com/codex/tasks/task_e_68538f70daa48322928751d2812468c9